### PR TITLE
Implement Planar-DAT surface truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ research playground built on top of it.
 |---|---|
 | **AVBD** (Giles, Diaz, Yuksel, SIGGRAPH 2025) | Core solver: per-color 6×6 LDLᵀ block primal, bounded AL duals, penalty ramping, α-stabilization, γ warm-start |
 | **VBD** (Chen et al., SIGGRAPH 2024) | Block-descent structure the GPU loop follows; trust-region step caps |
-| **[OGC](https://graphics.cs.utah.edu/research/projects/ogc/)** (Chen et al., SIGGRAPH 2025) | Contact model alignment (face blocks ⊥, radial boundaries) + the penetration-free machinery: 2-ring-excluded conservative bounds, Eq-28 warmstart truncation, counter-driven in-loop bound refresh (indirect dispatch, no CPU sync), divergent cloth-cloth log barrier |
+| **[OGC](https://graphics.cs.utah.edu/research/projects/ogc/)** (Chen et al., SIGGRAPH 2025) | Deformable contact-force model alignment (face blocks ⊥, radial boundaries), persistence, and divergent cloth-cloth log barrier; its isotropic conservative bound remains available as the legacy truncation mode |
+| **[Divide and Truncate / Planar-DAT](https://arxiv.org/abs/2604.15513)** (Chen et al., 2026) | Default direction-aware displacement truncation for deformable-surface V–T/E–E pairs, applied after forward initialization and every VBD color; OGC remains the contact-force model. Rigid curved-trajectory DAT, animated-DoF truncation, and explicit tet-inversion planes are not implemented |
 | **Stable Neo-Hookean** (Smith et al. 2018) | Tet FEM material with per-vertex SPD Hessian |
 | **Bergou et al. 2006** | Quadratic bending; hinge K derived numerically from the intrinsic unfolded shape |
 | **IPC / Codimensional IPC** (Li et al.) | Lagged friction formulation; contact-radius framing |

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -15,6 +15,14 @@ import SimCore
 //   5. n iterations of: per-color primal solve (6x6 LDL) + dual update
 //   6. BDF1 velocity finalize
 public final class GPUSolver {
+    /// Collision-safe displacement limiter for deformable surface V-T/E-E
+    /// motion. Planar-DAT is the production default; isotropicDAT remains an
+    /// exact in-process A/B and compatibility path.
+    public enum SurfaceTruncationMode: UInt32, Sendable {
+        case isotropicDAT = 1
+        case planarDAT = 2
+    }
+
     private static let jointMotorModeMask: UInt32 = 3 << 4
     private static let jointMotorModeImplicitPositionPD: UInt32 = 1 << 4
     private static let jointMotorModeExplicitTorquePD: UInt32 = 2 << 4
@@ -39,10 +47,23 @@ public final class GPUSolver {
     let numTris: Int
     public let tetBoundaryTris: [(Int, Int, Int)]
     var numEdges: Int = 0
+    var numPlanarDATEdges: Int = 0
     var numParticles: Int = 0
     let maxSoft: Int
     let softMapCapacity: Int
+    let maxIsotropicSoft: Int
+    let isotropicSoftMapCapacity: Int
     let elemHashSize: Int
+    let maxPlanarDATPairs: Int
+    var isotropicElemCellSize: Float = 1
+    var planarDATElemCellSize: Float = 1
+
+    public var surfaceTruncationMode: SurfaceTruncationMode = .planarDAT
+
+    enum PlanarDATPassSite: Equatable {
+        case predictor
+        case color(iteration: Int, color: Int)
+    }
 
     var params = SimParamsGPU()
 
@@ -124,6 +145,11 @@ public final class GPUSolver {
     var vtTrackBuf, eeTrackBuf, triAdjBuf: MTLBuffer
     var clothVertFlag: MTLBuffer
     var boundsBuf, ogcPrevBuf, ogcArgsBuf: MTLBuffer
+    // Full compact V-T/E-E safety neighborhood used by Planar-DAT. Contact
+    // emission consumes the same stream, so safety and force generation
+    // cannot silently disagree about which nearby primitives exist.
+    var planarDATPairsBuf, planarDATPairCountsBuf: MTLBuffer
+    var planarDATTBuf, planarDATArgsBuf: MTLBuffer
     var nbr2Start, nbr2Count, nbr2List: MTLBuffer
     var vertEdgeStart, vertEdgeCount, vertEdgeList: MTLBuffer
     public private(set) var surfaceTriCount: Int = 0
@@ -180,6 +206,16 @@ public final class GPUSolver {
         "color_scan",
         "color_scatter",
         "color_validate",
+        "dat_apply",
+        "dat_build_ee_pairs",
+        "dat_build_vt_pairs",
+        "dat_clear_element_grid",
+        "dat_clear_pair_counts",
+        "dat_emit_contacts",
+        "dat_finalize_pairs",
+        "dat_reanchor",
+        "dat_reduce",
+        "dat_restore_failed_surface",
         "diag_clear",
         "diag_error",
         "dual_all",
@@ -219,6 +255,10 @@ public final class GPUSolver {
     public private(set) var lastPairCandidates: Int = 0
     public private(set) var lastNumSoft: Int = 0
     public private(set) var lastSoftCandidates: Int = 0
+    public private(set) var lastPlanarDATPairs: Int = 0
+    public private(set) var lastPlanarDATVertexTrianglePairs: Int = 0
+    public private(set) var lastPlanarDATEdgeEdgePairs: Int = 0
+    public private(set) var lastPlanarDATTruncations: Int = 0
     // Start pessimistic so the first frame covers every possible color.
     public internal(set) var lastMaxColorUsed: Int = AVBD_MAX_COLORS - 1
     public private(set) var frameIndex: Int = 0
@@ -276,11 +316,9 @@ public final class GPUSolver {
         self.rigidMeshVertexCount = scene.rigidMeshes.reduce(0) {
             $0 + 3 * $1.triangles.count
         }
-        // Structural append bound: each collision-surface vertex retains at
-        // most four V-T candidates, each triangle four rigid-T candidates,
-        // and each authored cloth edge four E-E candidates. Derive the
-        // actual surface and unique edge counts instead of relying on the old
-        // 10*tri heuristic, which under-allocated disconnected/open meshes.
+        // Derive the actual surface and unique edge counts instead of relying
+        // on the old triangle heuristic, which under-allocated disconnected
+        // and open meshes.
         let collisionTriangles = scene.tris.map(\.ids) + tetBoundaryTris
         var surfaceParticles = Set<Int>()
         for (a, b, c) in collisionTriangles {
@@ -289,16 +327,39 @@ public final class GPUSolver {
             if scene.bodies[c].isParticle { surfaceParticles.insert(c) }
         }
         var contactEdges = Set<UInt64>()
-        for tri in scene.tris {
-            let (a, b, c) = tri.ids
+        for (a, b, c) in collisionTriangles {
             for (u, v) in [(a, b), (b, c), (a, c)] {
                 contactEdges.insert(UInt64(min(u, v)) << 32
                     | UInt64(max(u, v)))
             }
         }
-        self.maxSoft = max(1, 4 * surfaceParticles.count
-            + 4 * numTris + 4 * contactEdges.count)
+        var isotropicContactEdges = Set<UInt64>()
+        for tri in scene.tris {
+            let (a, b, c) = tri.ids
+            for (u, v) in [(a, b), (b, c), (a, c)] {
+                isotropicContactEdges.insert(UInt64(min(u, v)) << 32
+                    | UInt64(max(u, v)))
+            }
+        }
+        let planarPairCapacity = max(
+            1,
+            AVBD_PLANAR_DAT_PAIRS_PER_PARTICLE * surfaceParticles.count
+                + AVBD_PLANAR_DAT_PAIRS_PER_EDGE * contactEdges.count)
+        self.maxPlanarDATPairs = planarPairCapacity
+        // Full contact emission is no longer capped at four per owner. Keep a
+        // generous linear operational budget while the independent raw count
+        // remains exact and terminal on overflow; sizing this to the much
+        // larger complete safety-pair capacity would waste hundreds of MB on
+        // folds.
+        let planarContactBudget = min(
+            planarPairCapacity,
+            8 * surfaceParticles.count + 8 * contactEdges.count)
+        self.maxSoft = max(1, 4 * numTris + planarContactBudget)
         self.softMapCapacity = Self.nextPow2(max(64, 2 * maxSoft))
+        self.maxIsotropicSoft = max(1, 4 * surfaceParticles.count
+            + 4 * numTris + 4 * isotropicContactEdges.count)
+        self.isotropicSoftMapCapacity = Self.nextPow2(
+            max(64, 2 * maxIsotropicSoft))
         self.elemHashSize = Self.nextPow2(max(64, 2 * 4 * numTris))
 
         func makeBuf(_ length: Int, _ label: String) throws -> MTLBuffer {
@@ -356,6 +417,14 @@ public final class GPUSolver {
         boundsBuf = try makeBuf(nb * 4, "ogcBounds")
         ogcPrevBuf = try makeBuf(nb * 16, "ogcPrev")
         ogcArgsBuf = try makeBuf(3 * 4, "ogcArgs")
+        planarDATPairsBuf = try makeBuf(
+            maxPlanarDATPairs * 16, "planarDATPairs")
+        planarDATPairCountsBuf = try makeBuf(3 * 4, "planarDATPairCounts")
+        planarDATTBuf = try makeBuf(nb * 4, "planarDATT")
+        planarDATTBuf.contents().bindMemory(
+            to: UInt32.self, capacity: nb
+        ).initialize(repeating: Float(1).bitPattern, count: nb)
+        planarDATArgsBuf = try makeBuf(3 * 4, "planarDATArgs")
         // 2-ring CSR sized after derivation below (~19/vertex upper bound)
         nbr2Start = try makeBuf(nb * 4, "nbr2Start")
         nbr2Count = try makeBuf(nb * 4, "nbr2Count")
@@ -387,9 +456,11 @@ public final class GPUSolver {
         nbrList = try makeBuf(max(1, numTris * 6) * 4, "nbrList")
         elemCellCount = try makeBuf(elemHashSize * 4, "elemCellCount")
         elemCellStart = try makeBuf(elemHashSize * 4, "elemCellStart")
-        // AABB multi-cell: cover loops are clamped to 3x3x3 per element,
-        // so 27x capacity makes overflow impossible
-        elemCells = try makeBuf(max(1, 27 * (numTris + maxEdges)) * 4, "elemCells")
+        // AABB multi-cell: Planar-DAT permits a 4x4x4 cover (the isotropic
+        // path retains its legacy 3x3x3 logical span), so 64x capacity makes
+        // every healthy scatter exact.
+        elemCells = try makeBuf(max(1, 64 * (numTris + maxEdges)) * 4,
+                                "elemCells")
         elemSlot = try makeBuf(elemHashSize * 4, "elemCursor")
         softContacts = try makeBuf(maxSoft * MemoryLayout<SoftContactGPU>.stride, "softContacts")
         prevSoftContacts = try makeBuf(maxSoft * MemoryLayout<SoftContactGPU>.stride, "prevSoftContacts")
@@ -497,6 +568,45 @@ public final class GPUSolver {
         case staticColorCapacity(body: Int, required: Int, capacity: Int)
         case unresolvedColoring(frame: Int, conflictingBodies: Int)
 
+        // Planar-DAT host validation failures use the pre-existing extensible
+        // commandExecution payload rather than adding enum cases. That keeps
+        // exhaustive switches over RuntimeFailure source-compatible while the
+        // domain/code pair remains machine-readable.
+        static let planarDATFailureDomain = "PhysicsAVBD.PlanarDAT"
+        static let planarDATPairCapacityCode = 1
+        static let planarDATElementGridSpanCode = 2
+        static let planarDATInvalidAnchorCode = 3
+
+        public static func planarDATPairCapacity(
+            frame: Int, required: Int, capacity: Int
+        ) -> Self {
+            .commandExecution(
+                operation: "Planar-DAT safety validation", frame: frame,
+                status: 0, domain: planarDATFailureDomain,
+                code: planarDATPairCapacityCode,
+                message: "Planar-DAT safety-pair demand \(required) exceeds capacity \(capacity)")
+        }
+
+        public static func planarDATElementGridSpan(
+            frame: Int, offendingElements: Int
+        ) -> Self {
+            .commandExecution(
+                operation: "Planar-DAT safety validation", frame: frame,
+                status: 0, domain: planarDATFailureDomain,
+                code: planarDATElementGridSpanCode,
+                message: "\(offendingElements) Planar-DAT element AABBs exceeded the supported 4x4x4 grid span")
+        }
+
+        public static func planarDATInvalidAnchor(
+            frame: Int, offendingPairs: Int
+        ) -> Self {
+            .commandExecution(
+                operation: "Planar-DAT safety validation", frame: frame,
+                status: 0, domain: planarDATFailureDomain,
+                code: planarDATInvalidAnchorCode,
+                message: "\(offendingPairs) Planar-DAT pairs had a coincident or non-finite collision anchor")
+        }
+
         public var errorDescription: String? {
             switch self {
             case .commandBufferCreation(let operation, let frame):
@@ -505,6 +615,9 @@ public final class GPUSolver {
                 return "\(operation) frame \(frame): encoder creation failed at \(stage)"
             case .commandExecution(let operation, let frame, let status,
                                    let domain, let code, let message):
+                if domain == Self.planarDATFailureDomain {
+                    return "physics frame \(frame): \(message)"
+                }
                 let detail = domain.isEmpty ? message
                     : "\(domain) \(code): \(message)"
                 return "\(operation) frame \(frame): Metal status \(status) (\(detail))"
@@ -1065,7 +1178,7 @@ public final class GPUSolver {
         var topoEdgeSet = UInt64UniqueBuilder(capacity: collTris.count * 3)
         var topoEdgeKeys: [UInt64] = []
         topoEdgeKeys.reserveCapacity(collTris.count * 3)
-        var contactEdgeSet = UInt64UniqueBuilder(capacity: scene.tris.count * 3)
+        var contactEdgeSet = UInt64UniqueBuilder(capacity: collTris.count * 3)
         var contactEdgeKeys: [UInt64] = []
         contactEdgeKeys.reserveCapacity(scene.tris.count * 3)
         var maxElemR: Float = 0
@@ -1090,9 +1203,19 @@ public final class GPUSolver {
             maxElemR = max(maxElemR, max(distance(m, pa), max(distance(m, pb),
                                                                               distance(m, pc))) + thick)
         }
+        // Preserve authored cloth edges as the force-model prefix, then append
+        // synthesized tet-boundary edges for Planar-DAT safety only. V-T alone
+        // cannot detect every triangle-triangle crossing: an edge-edge event
+        // can occur with no vertex entering the opposing triangle. Keeping
+        // `numEdges` at the authored count also preserves the established
+        // contract that closed tet solids do not acquire cloth E-E forces.
         numEdges = contactEdgeKeys.count
+        for key in topoEdgeKeys where contactEdgeSet.insert(key) {
+            contactEdgeKeys.append(key)
+        }
+        numPlanarDATEdges = contactEdgeKeys.count
         let ep2 = edgesBuf.contents().bindMemory(to: SIMD2<UInt32>.self,
-                                                 capacity: max(1, numEdges))
+                                                 capacity: max(1, numPlanarDATEdges))
         var nbrArrays = [[UInt32]](repeating: [], count: numBodies)
         var vertEdges: [[UInt32]] = Array(repeating: [], count: numBodies)
         for key in topoEdgeKeys {
@@ -1387,18 +1510,32 @@ public final class GPUSolver {
         }
         let meanEdge = topoEdgeKeys.isEmpty ? 0.2 : edgeLenSum / Float(topoEdgeKeys.count)
         params.elemMargin = min(0.01, max(0.002, 0.5 * maxPartR))
+        // Planar-DAT queries a wider safety neighborhood than the active
+        // OGC force band. Anything beyond this radius is protected by the
+        // unconditional 0.5*gamma*rq accumulated-displacement cap.
+        let forceReach = 2 * maxPartR + params.elemMargin
+        params.planarDATQueryRadius = max(1.5 * forceReach,
+                                          0.75 * meanEdge)
+        params.planarDATRelaxation = 0.85
+        params.maxPlanarDATPairs = UInt32(maxPlanarDATPairs)
         // Detection-radius cells (AABB multi-cell insertion): reach must
         // cover skin + margin + velocity inflation (<= 0.3 cell, hence /0.7).
         // The broadphase bins fat element AABBs and clamps cover loops to
         // 3 cells/axis, so the cell also has to cover the largest element
         // radius plus collision padding.
         let reach = (2 * maxPartR + params.elemMargin) / 0.7
-        params.elemCellSize = max(0.02, max(max(reach, meanEdge * 1.05),
-                                            maxElemR + maxPartR
-                                                + params.elemMargin))
+        isotropicElemCellSize = max(
+            0.02, max(max(reach, meanEdge * 1.05),
+                      maxElemR + maxPartR + params.elemMargin))
+        params.surfaceContactCellSize = isotropicElemCellSize
+        planarDATElemCellSize = max(
+            0.02, max(max(reach, meanEdge * 1.05),
+                      2 * maxElemR + params.planarDATQueryRadius))
+        params.elemCellSize = planarDATElemCellSize
         params.elemHashSize = UInt32(elemHashSize)
         params.numTris = UInt32(numTris)
-        params.numEdges = UInt32(numEdges)
+        params.numEdges = UInt32(numPlanarDATEdges)
+        params.numSurfaceContactEdges = UInt32(numEdges)
         params.numParticles = UInt32(numParticles)
         params.maxSoft = UInt32(maxSoft)
         params.softMapCapacity = UInt32(softMapCapacity)
@@ -1832,6 +1969,22 @@ public final class GPUSolver {
         params.collisionMargin = max(settings.collisionMargin, 0)
         params.rigidLinearDamping = max(settings.rigidLinearDamping, 0)
         params.rigidAngularDamping = max(settings.rigidAngularDamping, 0)
+        params.surfaceTruncationMode = numParticles > 0
+            ? surfaceTruncationMode.rawValue : 0
+        params.maxPlanarDATPairs = UInt32(max(0, min(
+            maxPlanarDATPairs,
+            planarDATPairCapacityForTesting ?? maxPlanarDATPairs)))
+        params.numEdges = UInt32(surfaceTruncationMode == .planarDAT
+            ? numPlanarDATEdges : numEdges)
+        params.elemCellSize = surfaceTruncationMode == .planarDAT
+            ? planarDATElemCellSize : isotropicElemCellSize
+        let selectedSoftCapacity = surfaceTruncationMode == .planarDAT
+            ? maxSoft : maxIsotropicSoft
+        params.maxSoft = UInt32(max(
+            0, min(selectedSoftCapacity,
+                   planarDATSoftCapacityForTesting ?? selectedSoftCapacity)))
+        params.softMapCapacity = UInt32(surfaceTruncationMode == .planarDAT
+            ? softMapCapacity : isotropicSoftMapCapacity)
 
         if let env = ProcessInfo.processInfo.environment["AVBD_ROD_DECAY"],
            let v = Float(env) {
@@ -1912,6 +2065,8 @@ public final class GPUSolver {
         let counterSnapshot: MTLBuffer
         let frame: Int
         let usesDynamicColoring: Bool
+        let softCapacity: Int
+        let planarDATCapacity: Int
     }
     private var inflight: [StepSubmission] = []
     private let statsLock = NSLock()
@@ -1932,6 +2087,9 @@ public final class GPUSolver {
     // between submissions is safe even if an older command is still in flight.
     var commandBufferFactoryForTesting: (() -> MTLCommandBuffer?)?
     var deniedEncoderStageForTesting: String?
+    var planarDATPairCapacityForTesting: Int?
+    var planarDATSoftCapacityForTesting: Int?
+    var planarDATPassObserverForTesting: ((PlanarDATPassSite) -> Void)?
     var completionFailureForTesting: ((String, Int) -> RuntimeFailure?)?
     var inflightCountForTesting: Int { inflight.count }
 
@@ -2506,12 +2664,24 @@ public final class GPUSolver {
         let pairs = Int(ctr[GPUCounters.pairs])
         let soft = Int(ctr[GPUCounters.soft])
         let colorConflicts = Int(ctr[GPUCounters.colorConflicts])
+        let planarDATPairs = Int(ctr[GPUCounters.planarDATPairs])
+        let planarDATVT = Int(ctr[GPUCounters.planarDATVertexTrianglePairs])
+        let planarDATEE = Int(ctr[GPUCounters.planarDATEdgeEdgePairs])
+        let planarDATGridOverflows = Int(
+            ctr[GPUCounters.planarDATGridOverflows])
+        let planarDATInvalidAnchors = Int(
+            ctr[GPUCounters.planarDATInvalidAnchors])
+        let planarDATTruncations = Int(ctr[GPUCounters.planarDATTruncations])
 
         statsLock.lock()
         lastPairCandidates = pairCandidates
         lastNumPairs = pairs
         lastSoftCandidates = softCandidates
         lastNumSoft = soft
+        lastPlanarDATPairs = planarDATPairs
+        lastPlanarDATVertexTrianglePairs = planarDATVT
+        lastPlanarDATEdgeEdgePairs = planarDATEE
+        lastPlanarDATTruncations = planarDATTruncations
         if submission.usesDynamicColoring {
             var counts = [Int]()
             counts.reserveCapacity(AVBD_MAX_COLORS)
@@ -2531,10 +2701,25 @@ public final class GPUSolver {
                 frame: submission.frame, required: pairCandidates,
                 capacity: maxPairs))
         }
-        if softCandidates > maxSoft {
+        if softCandidates > submission.softCapacity {
             throw latch(.softContactCapacity(
                 frame: submission.frame, required: softCandidates,
-                capacity: maxSoft))
+                capacity: submission.softCapacity))
+        }
+        if planarDATPairs > submission.planarDATCapacity {
+            throw latch(.planarDATPairCapacity(
+                frame: submission.frame, required: planarDATPairs,
+                capacity: submission.planarDATCapacity))
+        }
+        if planarDATGridOverflows > 0 {
+            throw latch(.planarDATElementGridSpan(
+                frame: submission.frame,
+                offendingElements: planarDATGridOverflows))
+        }
+        if planarDATInvalidAnchors > 0 {
+            throw latch(.planarDATInvalidAnchor(
+                frame: submission.frame,
+                offendingPairs: planarDATInvalidAnchors))
         }
         if colorConflicts > 0 {
             throw latch(.unresolvedColoring(
@@ -2827,6 +3012,209 @@ public final class GPUSolver {
         }
         var P = params
         var nExcl = numExclusions
+        let isPlanarDAT = P.surfaceTruncationMode
+            == SurfaceTruncationMode.planarDAT.rawValue
+
+        func encodeElementGrid(_ encoder: MTLComputeCommandEncoder,
+                               clearFirst: Bool) {
+            if clearFirst {
+                dispatch1D(encoder, "dat_clear_element_grid", elemHashSize) { e in
+                    e.setBuffer(self.elemCellCount, offset: 0, index: 0)
+                    e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                               index: 1)
+                }
+            }
+            dispatch1D(encoder, "el_count", numTris + Int(P.numEdges)) { e in
+                e.setBuffer(self.posLin, offset: 0, index: 0)
+                e.setBuffer(self.trisBuf, offset: 0, index: 1)
+                e.setBuffer(self.edgesBuf, offset: 0, index: 2)
+                e.setBuffer(self.shape, offset: 0, index: 3)
+                e.setBuffer(self.elemCellCount, offset: 0, index: 4)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 5)
+                e.setBuffer(self.counters, offset: 0, index: 6)
+            }
+            encodeScan(encoder, input: elemCellCount,
+                       output: elemCellStart, count: elemHashSize)
+            var hashSize = UInt32(elemHashSize)
+            dispatch1D(encoder, "adj_copy_cursor", elemHashSize) { e in
+                e.setBuffer(self.elemCellStart, offset: 0, index: 0)
+                e.setBuffer(self.elemSlot, offset: 0, index: 1)
+                e.setBytes(&hashSize, length: 4, index: 2)
+            }
+            dispatch1D(encoder, "el_scatter", numTris + Int(P.numEdges)) { e in
+                e.setBuffer(self.posLin, offset: 0, index: 0)
+                e.setBuffer(self.trisBuf, offset: 0, index: 1)
+                e.setBuffer(self.edgesBuf, offset: 0, index: 2)
+                e.setBuffer(self.shape, offset: 0, index: 3)
+                e.setBuffer(self.elemSlot, offset: 0, index: 4)
+                e.setBuffer(self.elemCells, offset: 0, index: 5)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 6)
+            }
+        }
+
+        func encodePlanarPairBuild(_ encoder: MTLComputeCommandEncoder) {
+            dispatch1D(encoder, "dat_clear_pair_counts", 3) { e in
+                e.setBuffer(self.planarDATPairCountsBuf, offset: 0, index: 0)
+            }
+            if numParticles > 0
+                && ProcessInfo.processInfo.environment["AVBD_NO_VT"] == nil {
+                encoder.setComputePipelineState(ps("dat_build_vt_pairs"))
+                encoder.setBuffer(self.posLin, offset: 0, index: 0)
+                encoder.setBuffer(self.particleIdxBuf, offset: 0, index: 1)
+                encoder.setBuffer(self.trisBuf, offset: 0, index: 2)
+                encoder.setBuffer(self.elemCellStart, offset: 0, index: 3)
+                encoder.setBuffer(self.elemCellCount, offset: 0, index: 4)
+                encoder.setBuffer(self.elemCells, offset: 0, index: 5)
+                // Newton's default topology threshold: one-edge-ring
+                // primitives are excluded once, then the exact same retained
+                // pair set feeds OGC forces and Planar-DAT.
+                encoder.setBuffer(self.nbrStart, offset: 0, index: 6)
+                encoder.setBuffer(self.nbrCount, offset: 0, index: 7)
+                encoder.setBuffer(self.nbrList, offset: 0, index: 8)
+                encoder.setBuffer(self.shape, offset: 0, index: 9)
+                encoder.setBuffer(self.clothGroupBuf, offset: 0, index: 10)
+                encoder.setBuffer(self.clothVertFlag, offset: 0, index: 11)
+                encoder.setBuffer(self.planarDATPairsBuf, offset: 0, index: 12)
+                encoder.setBuffer(self.planarDATPairCountsBuf, offset: 0, index: 13)
+                encoder.setBuffer(self.counters, offset: 0, index: 14)
+                encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                                 index: 15)
+                encoder.setBuffer(self.edgesBuf, offset: 0, index: 19)
+                encoder.dispatchThreadgroups(
+                    MTLSize(width: numParticles, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 64, height: 1,
+                                                   depth: 1))
+            }
+            if P.numEdges > 0
+                && ProcessInfo.processInfo.environment["AVBD_NO_EE"] == nil {
+                encoder.setComputePipelineState(ps("dat_build_ee_pairs"))
+                encoder.setBuffer(self.posLin, offset: 0, index: 0)
+                encoder.setBuffer(self.edgesBuf, offset: 0, index: 1)
+                encoder.setBuffer(self.trisBuf, offset: 0, index: 2)
+                encoder.setBuffer(self.elemCellStart, offset: 0, index: 3)
+                encoder.setBuffer(self.elemCellCount, offset: 0, index: 4)
+                encoder.setBuffer(self.elemCells, offset: 0, index: 5)
+                encoder.setBuffer(self.nbrStart, offset: 0, index: 6)
+                encoder.setBuffer(self.nbrCount, offset: 0, index: 7)
+                encoder.setBuffer(self.nbrList, offset: 0, index: 8)
+                encoder.setBuffer(self.shape, offset: 0, index: 9)
+                encoder.setBuffer(self.clothGroupBuf, offset: 0, index: 10)
+                encoder.setBuffer(self.clothVertFlag, offset: 0, index: 11)
+                encoder.setBuffer(self.planarDATPairsBuf, offset: 0, index: 12)
+                encoder.setBuffer(self.planarDATPairCountsBuf, offset: 0, index: 13)
+                encoder.setBuffer(self.counters, offset: 0, index: 14)
+                encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                                 index: 15)
+                encoder.dispatchThreadgroups(
+                    MTLSize(width: Int(P.numEdges), height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 64, height: 1,
+                                                   depth: 1))
+            }
+            dispatch1D(encoder, "dat_finalize_pairs", 1) { e in
+                e.setBuffer(self.planarDATPairCountsBuf, offset: 0, index: 0)
+                e.setBuffer(self.counters, offset: 0, index: 1)
+                e.setBuffer(self.planarDATArgsBuf, offset: 0, index: 2)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 3)
+            }
+        }
+
+        func encodePlanarContacts(_ encoder: MTLComputeCommandEncoder,
+                                  pairs: MTLBuffer,
+                                  pairCounts: MTLBuffer,
+                                  positions: MTLBuffer,
+                                  referencePositions: MTLBuffer) {
+            let contactPSO = ps("dat_emit_contacts")
+            encoder.setComputePipelineState(contactPSO)
+            encoder.setBuffer(pairs, offset: 0, index: 0)
+            encoder.setBuffer(positions, offset: 0, index: 1)
+            encoder.setBuffer(shape, offset: 0, index: 2)
+            encoder.setBuffer(props, offset: 0, index: 3)
+            encoder.setBuffer(velLin, offset: 0, index: 4)
+            encoder.setBuffer(trisBuf, offset: 0, index: 5)
+            encoder.setBuffer(edgesBuf, offset: 0, index: 6)
+            encoder.setBuffer(softContacts, offset: 0, index: 7)
+            encoder.setBuffer(counters, offset: 0, index: 8)
+            encoder.setBuffer(prevSoftContacts, offset: 0, index: 9)
+            encoder.setBuffer(softMapKeyA, offset: 0, index: 10)
+            encoder.setBuffer(softMapKeyB, offset: 0, index: 11)
+            encoder.setBuffer(softMapVal, offset: 0, index: 12)
+            encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                             index: 13)
+            encoder.setBuffer(pairCounts, offset: 0, index: 14)
+            // initLin deliberately stores only coordinates (w == 0). Keep
+            // dynamic mass classification bound to the authoritative state.
+            encoder.setBuffer(posLin, offset: 0, index: 15)
+            // Contacts are detected at the accepted predictor pose but the
+            // solver linearizes from initLin. The kernel reconstructs C0 from
+            // these exact step-start coordinates rather than double-counting
+            // predictor displacement.
+            encoder.setBuffer(referencePositions, offset: 0, index: 16)
+            encoder.dispatchThreadgroups(
+                indirectBuffer: planarDATArgsBuf,
+                indirectBufferOffset: 0,
+                threadsPerThreadgroup: MTLSize(width: 64, height: 1,
+                                               depth: 1))
+        }
+
+        func encodeSoftContactMap(_ encoder: MTLComputeCommandEncoder) {
+            dispatch1D(encoder, "soft_finalize", 1) { e in
+                e.setBuffer(self.counters, offset: 0, index: 0)
+                e.setBuffer(self.dispatchArgs, offset: 0, index: 1)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 2)
+            }
+            var clearCapacity = UInt32(self.softMapCapacity)
+            dispatch1D(encoder, "softmap_clear", self.softMapCapacity) { e in
+                e.setBuffer(self.softMapKeyA, offset: 0, index: 0)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 1)
+                e.setBytes(&clearCapacity, length: 4, index: 2)
+            }
+            dispatch1D(encoder, "softmap_insert", Int(P.maxSoft)) { e in
+                e.setBuffer(self.softContacts, offset: 0, index: 0)
+                e.setBuffer(self.softMapKeyA, offset: 0, index: 1)
+                e.setBuffer(self.softMapKeyB, offset: 0, index: 2)
+                e.setBuffer(self.softMapVal, offset: 0, index: 3)
+                e.setBuffer(self.counters, offset: 0, index: 4)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 5)
+            }
+        }
+
+        func encodePlanarPass(_ encoder: MTLComputeCommandEncoder,
+                              pairs: MTLBuffer,
+                              pairCounts: MTLBuffer) {
+            let reducePSO = ps("dat_reduce")
+            encoder.setComputePipelineState(reducePSO)
+            encoder.setBuffer(pairs, offset: 0, index: 0)
+            encoder.setBuffer(posLin, offset: 0, index: 1)
+            encoder.setBuffer(ogcPrevBuf, offset: 0, index: 2)
+            encoder.setBuffer(trisBuf, offset: 0, index: 3)
+            encoder.setBuffer(edgesBuf, offset: 0, index: 4)
+            encoder.setBuffer(planarDATTBuf, offset: 0, index: 5)
+            encoder.setBuffer(pairCounts, offset: 0, index: 6)
+            encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                             index: 7)
+            encoder.setBuffer(counters, offset: 0, index: 8)
+            encoder.dispatchThreadgroups(
+                indirectBuffer: planarDATArgsBuf,
+                indirectBufferOffset: 0,
+                threadsPerThreadgroup: MTLSize(width: 64, height: 1,
+                                               depth: 1))
+            dispatch1D(encoder, "dat_apply", numParticles) { e in
+                e.setBuffer(self.posLin, offset: 0, index: 0)
+                e.setBuffer(self.ogcPrevBuf, offset: 0, index: 1)
+                e.setBuffer(self.particleIdxBuf, offset: 0, index: 2)
+                e.setBuffer(self.planarDATTBuf, offset: 0, index: 3)
+                e.setBuffer(pairCounts, offset: 0, index: 4)
+                e.setBuffer(self.counters, offset: 0, index: 5)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 6)
+            }
+        }
 
         // Broadphase
         if profiling { try stage("bp-count") }
@@ -2961,36 +3349,14 @@ public final class GPUSolver {
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 5)
         }
 
-        // ---- Cloth element contacts: bin triangles into the element grid,
-        // emit V-T and rigid-feature-T records (warm-started from the soft
-        // persistence map), then rebuild the map for next frame. Runs at
-        // start-of-step poses like the rigid narrowphase.
+            // ---- Soft contacts. Planar-DAT replaces the legacy best-four
+            // VT/EE trackers with exact endpoint queries; rigid-triangle
+            // records remain on their existing start-pose path. The accepted
+            // Planar stream is emitted after predictor acceptance below.
         if numTris > 0 {
+            if !isPlanarDAT {
             try stage("el-bin")
-            dispatch1D(enc, "el_count", numTris + Int(P.numEdges)) { e in
-                e.setBuffer(self.posLin, offset: 0, index: 0)
-                e.setBuffer(self.trisBuf, offset: 0, index: 1)
-                e.setBuffer(self.edgesBuf, offset: 0, index: 2)
-                e.setBuffer(self.shape, offset: 0, index: 3)
-                e.setBuffer(self.elemCellCount, offset: 0, index: 4)
-                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 5)
-            }
-            encodeScan(enc, input: elemCellCount, output: elemCellStart, count: elemHashSize)
-            var ehs = UInt32(elemHashSize)
-            dispatch1D(enc, "adj_copy_cursor", elemHashSize) { e in
-                e.setBuffer(self.elemCellStart, offset: 0, index: 0)
-                e.setBuffer(self.elemSlot, offset: 0, index: 1)
-                e.setBytes(&ehs, length: 4, index: 2)
-            }
-            dispatch1D(enc, "el_scatter", numTris + Int(P.numEdges)) { e in
-                e.setBuffer(self.posLin, offset: 0, index: 0)
-                e.setBuffer(self.trisBuf, offset: 0, index: 1)
-                e.setBuffer(self.edgesBuf, offset: 0, index: 2)
-                e.setBuffer(self.shape, offset: 0, index: 3)
-                e.setBuffer(self.elemSlot, offset: 0, index: 4)
-                e.setBuffer(self.elemCells, offset: 0, index: 5)
-                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 6)
-            }
+            encodeElementGrid(enc, clearFirst: false)
             try stage("vt-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_VT"] == nil {
             dispatch1D(enc, "vt_emit", numParticles) { e in
@@ -3025,7 +3391,7 @@ public final class GPUSolver {
             }
             try stage("ee-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_EE"] == nil {
-            dispatch1D(enc, "ee_emit", numEdges) { e in
+            dispatch1D(enc, "ee_emit", Int(P.numEdges)) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(self.shape, offset: 0, index: 1)
                 e.setBuffer(self.props, offset: 0, index: 2)
@@ -3056,6 +3422,13 @@ public final class GPUSolver {
                 e.setBuffer(self.clothVertFlag, offset: 0, index: 27)
             }
             }
+            }
+            else {
+                try stage("el-bin")
+                encodeElementGrid(enc, clearFirst: false)
+                try stage("dat-pairs")
+                encodePlanarPairBuild(enc)
+            }
             try stage("rt-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_RT"] == nil {
             dispatch1D(enc, "rt_emit", numTris) { e in
@@ -3082,23 +3455,9 @@ public final class GPUSolver {
                 e.setBuffer(self.hashedRigidIdx, offset: 0, index: 20)
             }
             }
-            try stage("softmap")
-            dispatch1D(enc, "soft_finalize", 1) { e in
-                e.setBuffer(self.counters, offset: 0, index: 0)
-                e.setBuffer(self.dispatchArgs, offset: 0, index: 1)
-                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 2)
-            }
-            dispatch1D(enc, "softmap_clear", softMapCapacity) { e in
-                e.setBuffer(self.softMapKeyA, offset: 0, index: 0)
-                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 1)
-            }
-            dispatch1D(enc, "softmap_insert", maxSoft) { e in
-                e.setBuffer(self.softContacts, offset: 0, index: 0)
-                e.setBuffer(self.softMapKeyA, offset: 0, index: 1)
-                e.setBuffer(self.softMapKeyB, offset: 0, index: 2)
-                e.setBuffer(self.softMapVal, offset: 0, index: 3)
-                e.setBuffer(self.counters, offset: 0, index: 4)
-                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 5)
+            if !isPlanarDAT {
+                try stage("softmap")
+                encodeSoftContactMap(enc)
             }
         }
 
@@ -3126,10 +3485,46 @@ public final class GPUSolver {
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 9)
             e.setBuffer(self.ogcPrevBuf, offset: 0, index: 10)
             e.setBuffer(self.boundsBuf, offset: 0, index: 11)
-            var doOgc: UInt32 = self.numTris > 0 ? 1 : 0
-            e.setBytes(&doOgc, length: 4, index: 12)
+            var truncationMode = P.surfaceTruncationMode
+            e.setBytes(&truncationMode, length: 4, index: 12)
             e.setBuffer(self.shape, offset: 0, index: 13)
             e.setBuffer(self.gravityScale, offset: 0, index: 14)
+        }
+
+        if isPlanarDAT {
+            // Start from the exact rq neighborhood. Since the predictor caps
+            // each side to R=0.5*gamma*rq, a pair outside this query cannot
+            // close its positive gap before the accepted-pose query below.
+            try stage("dat-predict")
+            let predictorSite = PlanarDATPassSite.predictor
+            planarDATPassObserverForTesting?(predictorSite)
+            encodePlanarPass(enc, pairs: planarDATPairsBuf,
+                             pairCounts: planarDATPairCountsBuf)
+
+            // Newton's two-detection schedule: rebuild at the accepted
+            // predictor pose, then use this exact rq set for OGC forces and
+            // every per-color DAT pass. Clearing these working counts does
+            // not clear the sticky peak/failure counters, so an overflow in
+            // either query remains terminal and restores the failed frame.
+            try stage("dat-accepted-grid")
+            encodeElementGrid(enc, clearFirst: true)
+            try stage("dat-accepted-pairs")
+            encodePlanarPairBuild(enc)
+            try stage("vt-ee-emit")
+            encodePlanarContacts(
+                enc, pairs: planarDATPairsBuf,
+                pairCounts: planarDATPairCountsBuf,
+                positions: posLin, referencePositions: initLin)
+            try stage("softmap")
+            encodeSoftContactMap(enc)
+            try stage("dat-reanchor")
+            dispatch1D(enc, "dat_reanchor", numParticles) { e in
+                e.setBuffer(self.posLin, offset: 0, index: 0)
+                e.setBuffer(self.particleIdxBuf, offset: 0, index: 1)
+                e.setBuffer(self.ogcPrevBuf, offset: 0, index: 2)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 3)
+            }
         }
 
         try stage("adjacency")
@@ -3273,7 +3668,7 @@ public final class GPUSolver {
         let persistentRequested = ProcessInfo.processInfo.environment[
             "AVBD_PERSIST"] != nil
             && ProcessInfo.processInfo.environment["AVBD_NO_PERSIST"] == nil
-        if multiOK && numBodies <= 4096 {
+        if multiOK && !isPlanarDAT && numBodies <= 4096 {
             let tgW = min(256, multiPSO.maxTotalThreadsPerThreadgroup)
             var ntg = UInt32(min(8, max(1, (numBodies + tgW - 1) / tgW + 1)))
             enc.setComputePipelineState(multiPSO)
@@ -3305,7 +3700,7 @@ public final class GPUSolver {
             enc.setBuffer(counters, offset: 0, index: 28)
             enc.dispatchThreadgroups(MTLSize(width: Int(ntg), height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: tgW, height: 1, depth: 1))
-        } else if persistentRequested
+        } else if persistentRequested && !isPlanarDAT
                     && numBodies <= persistPSO.maxTotalThreadsPerThreadgroup {
             // small scene: the whole solve loop in ONE dispatch — hundreds
             // of per-dispatch launch/barrier latencies become threadgroup
@@ -3429,6 +3824,33 @@ public final class GPUSolver {
                         MTLSize(width: (splitSizes[c] + 63) / 64, height: 1, depth: 1),
                         threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
                 }
+                if isPlanarDAT {
+                    // A VBD color is a Gauss-Seidel iteration in DAT's
+                    // terminology: later colors must never observe a trial
+                    // pose that already crossed one of the fixed division
+                    // planes. Reduce and apply immediately after every color.
+                    let passSite = PlanarDATPassSite.color(
+                        iteration: it, color: c)
+                    planarDATPassObserverForTesting?(passSite)
+                    encodePlanarPass(
+                        enc, pairs: planarDATPairsBuf,
+                        pairCounts: planarDATPairCountsBuf)
+                    if c + 1 < colorBound {
+                        // DAT reuses the low slots through index 8. Restore
+                        // every overwritten primal binding before the next
+                        // color; the higher bindings and cIdx stay intact.
+                        enc.setComputePipelineState(primalPSO)
+                        enc.setBuffer(posLin, offset: 0, index: 0)
+                        enc.setBuffer(posAng, offset: 0, index: 1)
+                        enc.setBuffer(initLin, offset: 0, index: 2)
+                        enc.setBuffer(initAng, offset: 0, index: 3)
+                        enc.setBuffer(inertLin, offset: 0, index: 4)
+                        enc.setBuffer(inertAng, offset: 0, index: 5)
+                        enc.setBuffer(props, offset: 0, index: 6)
+                        enc.setBuffer(joints, offset: 0, index: 7)
+                        enc.setBuffer(springs, offset: 0, index: 8)
+                    }
+                }
             }
             if profiling { try stage("solve-dual") }
             dispatchIndirect(enc, "dual_all", argsOffset: 6) { e in
@@ -3447,7 +3869,8 @@ public final class GPUSolver {
             // turns the exceed counter into indirect dispatch args, so the
             // refresh runs ONLY in iterations where >1% of particles were
             // bound-limited — settled scenes pay an empty dispatch
-            if numParticles > 0 && it + 1 < settings.iterations {
+            if !isPlanarDAT && numParticles > 0
+                && it + 1 < settings.iterations {
                 dispatch1D(enc, "ogc_refresh_args", 1) { e in
                     e.setBuffer(self.counters, offset: 0, index: 0)
                     e.setBuffer(self.ogcArgsBuf, offset: 0, index: 1)
@@ -3478,6 +3901,16 @@ public final class GPUSolver {
 
         }
         try stage("finalize")
+        if isPlanarDAT {
+            dispatch1D(enc, "dat_restore_failed_surface", numParticles) { e in
+                e.setBuffer(self.posLin, offset: 0, index: 0)
+                e.setBuffer(self.initLin, offset: 0, index: 1)
+                e.setBuffer(self.particleIdxBuf, offset: 0, index: 2)
+                e.setBuffer(self.counters, offset: 0, index: 3)
+                e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
+                           index: 4)
+            }
+        }
         dispatch1D(enc, "finalize_velocities", numBodies) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.posAng, offset: 0, index: 1)
@@ -3555,7 +3988,9 @@ public final class GPUSolver {
         let submission = StepSubmission(
             commandBuffer: cmd1, counterSnapshot: counterSnapshot,
             frame: submittedFrame,
-            usesDynamicColoring: usesDynamicColoring)
+            usesDynamicColoring: usesDynamicColoring,
+            softCapacity: Int(P.maxSoft),
+            planarDATCapacity: Int(P.maxPlanarDATPairs))
         cmd1.commit()
 
         // Buffer identity is a submitted-frame contract even if retirement

--- a/Sources/PhysicsAVBD/GPU/GPUTypes.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUTypes.swift
@@ -6,6 +6,15 @@ import SimCore
 
 public let AVBD_MAX_COLORS = 64
 public let AVBD_MAX_CONTACTS = 8
+/// Default compact safety-pair budget. Unlike Newton's per-owner 32/64
+/// slices, this is one global stream: sparse rows can lend capacity to dense
+/// rows, while the raw demand counter still makes overflow fail closed.
+// Allocation heuristics, not silent per-owner caps: both exact endpoint
+// queries append into one reusable global stream and fail closed if either
+// query's total demand exceeds it. Keep enough headroom for folded multilayer
+// scenes while retaining memory linear in mesh size.
+public let AVBD_PLANAR_DAT_PAIRS_PER_PARTICLE = 64
+public let AVBD_PLANAR_DAT_PAIRS_PER_EDGE = 128
 
 public struct SimParamsGPU {
     public var dt: Float = 1.0 / 60.0
@@ -48,6 +57,19 @@ public struct SimParamsGPU {
     public var collisionMargin: Float = 0.01
     public var rigidLinearDamping: Float = 0
     public var rigidAngularDamping: Float = 0
+    /// 0 = disabled/no surface, 1 = legacy isotropic OGC bound,
+    /// 2 = direction-aware Planar-DAT.
+    public var surfaceTruncationMode: UInt32 = 0
+    public var maxPlanarDATPairs: UInt32 = 0
+    /// Authored cloth edges eligible for the OGC E-E force model. Planar-DAT
+    /// may additionally protect synthesized tet-boundary edges.
+    public var numSurfaceContactEdges: UInt32 = 0
+    public var planarDATQueryRadius: Float = 0
+    public var planarDATRelaxation: Float = 0.85
+    /// Legacy OGC velocity-inflation cap. Kept separate from the wider
+    /// Planar-DAT broadphase cell so changing safety-query geometry cannot
+    /// silently widen the force model.
+    public var surfaceContactCellSize: Float = 1
 }
 
 extension SimParamsGPU: Equatable {}
@@ -160,6 +182,14 @@ public enum GPUCounters {
     /// Dynamic bodies that still share a color with a graph neighbor after
     /// the final coloring pass. Any nonzero value invalidates the solve.
     public static let colorConflicts = 6
-    public static let colorBase = 8
-    public static let total = 8 + 2 * AVBD_MAX_COLORS
+    /// Raw compact Planar-DAT pair demand before storage clipping.
+    public static let planarDATPairs = 7
+    public static let planarDATVertexTrianglePairs = 8
+    public static let planarDATEdgeEdgePairs = 9
+    /// Element AABB exceeded the truncation mode's supported grid span.
+    public static let planarDATGridOverflows = 10
+    public static let planarDATInvalidAnchors = 11
+    public static let planarDATTruncations = 12
+    public static let colorBase = 13
+    public static let total = 13 + 2 * AVBD_MAX_COLORS
 }

--- a/Sources/PhysicsAVBD/Shaders/00_common.metal
+++ b/Sources/PhysicsAVBD/Shaders/00_common.metal
@@ -278,6 +278,12 @@ struct SimParams {
     float collisionMargin;  // scene-scale rigid contact skin/margin (metres)
     float rigidLinearDamping;  // isotropic viscous drag, per second
     float rigidAngularDamping;
+    uint surfaceTruncationMode; // 0 off, 1 isotropic, 2 Planar-DAT
+    uint maxPlanarDATPairs;     // compact V-T + canonical E-E pair capacity
+    uint numSurfaceContactEdges; // authored cloth E-E force-model prefix
+    float planarDATQueryRadius;
+    float planarDATRelaxation;
+    float surfaceContactCellSize; // legacy OGC velocity-inflation reference
 };
 
 inline float combine_friction(float a, float b, uint mode) {
@@ -381,7 +387,9 @@ struct SoftContactGPU {
     float4 normal;      // xyz = contact normal (pushes slot 0 along +n), w = friction
     float4 anchorA;     // xyz = slot-0 LOCAL anchor (rigid slot 0 only); w = flag bits
     float4 weights;     // signed weight per slot (gradient_i = w_i * basis row)
-    float4 C0;          // xyz = (n,t1,t2) constraint at detection; w = lambda cap
+    // xyz = (n,t1,t2) constraint linearized at step start. Contacts found at
+    // the accepted predictor pose are back-evaluated to that same reference.
+    float4 C0;          // w = lambda cap
     float4 lambda;      // xyz = duals; w = persistence key A (bits)
     float4 penalty;     // xyz = penalties; w = persistence key B (bits)
 };
@@ -429,6 +437,27 @@ struct ManifoldGPU {
 #define CTR_PAIR_CANDIDATES 4      // rigid demand before capacity clipping
 #define CTR_SOFT_CANDIDATES 5      // soft demand before capacity clipping
 #define CTR_COLOR_CONFLICTS 6      // unresolved dynamic-color graph edges
-#define CTR_COLOR_BASE 8           // MAX_COLORS entries
-#define CTR_SCATTER_BASE (8 + MAX_COLORS)  // MAX_COLORS scatter cursors
-#define CTR_TOTAL (8 + 2 * MAX_COLORS)
+#define CTR_DAT_PAIRS 7            // raw compact DAT pair demand
+#define CTR_DAT_VT_PAIRS 8         // raw V-T DAT pair demand
+#define CTR_DAT_EE_PAIRS 9         // raw canonical E-E DAT pair demand
+#define CTR_DAT_GRID_OVERFLOW 10   // element AABB exceeded supported span
+#define CTR_DAT_INVALID_ANCHOR 11  // coincident/non-finite fixed pair anchor
+#define CTR_DAT_TRUNCATIONS 12     // particles directionally/cap truncated
+#define CTR_COLOR_BASE 13          // MAX_COLORS entries
+#define CTR_SCATTER_BASE (13 + MAX_COLORS) // MAX_COLORS scatter cursors
+#define CTR_TOTAL (13 + 2 * MAX_COLORS)
+
+#define SURFACE_TRUNCATION_ISOTROPIC 1u
+#define SURFACE_TRUNCATION_PLANAR_DAT 2u
+#define DAT_PAIR_VT 0u
+#define DAT_PAIR_EE 1u
+#define DAT_PAIR_TRUNCATE 1u
+#define DAT_PAIR_CONTACT 2u
+
+struct PlanarDATPairGPU {
+    // kind, owner vertex/edge, opposing triangle/edge, eligibility flags.
+    // One one-ring-filtered stream feeds both consumers. Same connected-solid
+    // safety pairs and synthesized tet boundary edges are truncation-only so
+    // Planar-DAT does not expand the established OGC force-model eligibility.
+    uint4 data;
+};

--- a/Sources/PhysicsAVBD/Shaders/25_cloth.metal
+++ b/Sources/PhysicsAVBD/Shaders/25_cloth.metal
@@ -8,7 +8,9 @@ using namespace metal;
 // the full AVBD treatment downstream: persistent warm-started lambda/penalty,
 // bounded duals scaled to participant masses, graph-coloring conflicts across
 // the whole stencil, and the block-descent primal.
-// Runs at start-of-step poses, before body prediction (like np_collide).
+// Legacy isotropic V-T/E-E and rigid-T detection run at step start. The
+// Planar-DAT V-T/E-E stream is rebuilt at the accepted predictor pose in
+// 27_planar_dat.metal, then feeds the same downstream contact machinery.
 // ============================================================================
 
 #define VT_MAX_PER_VERTEX 4u
@@ -99,9 +101,10 @@ inline int softMapFind(device const atomic_uint* keyAs,
 kernel void softmap_clear(
     device atomic_uint* keyAs       [[buffer(0)]],
     constant SimParams& P           [[buffer(1)]],
+    constant uint& clearCapacity    [[buffer(2)]],
     uint gid                        [[thread_position_in_grid]])
 {
-    if (gid < P.softMapCapacity)
+    if (gid < clearCapacity)
         atomic_store_explicit(&keyAs[gid], 0u, memory_order_relaxed);
 }
 
@@ -137,8 +140,9 @@ kernel void softmap_insert(
 // overlaps, at a DETECTION-radius cell size (coarse centroid cells made
 // every query scan most of the sheet at high resolution: ~1000 candidate
 // tests per vertex; AABB multi-cell brings it to ~10-30). Cover loops are
-// clamped to 3x3x3 — the cell size is chosen at init so elements span at
-// most ~2 cells per axis with stretch headroom.
+// Isotropic-DAT retains its exact legacy 3x3x3 cover. Planar-DAT permits a
+// 4x4x4 cover as fail-closed floating-point boundary headroom without
+// coarsening every hash bucket.
 // ----------------------------------------------------------------------------
 inline void elemBounds(device const float4* posLin,
                        device const float4* shape,
@@ -150,15 +154,26 @@ inline void elemBounds(device const float4* posLin,
     if (gid < P.numTris) {
         uint4 t = tris[gid];
         float3 a = posLin[t.x].xyz, b = posLin[t.y].xyz, c = posLin[t.z].xyz;
-        float pad = max(fabs(shape[t.x].w),
-                        max(fabs(shape[t.y].w), fabs(shape[t.z].w)))
-                  + P.elemMargin;
+        float contactPad = max(fabs(shape[t.x].w),
+                               max(fabs(shape[t.y].w), fabs(shape[t.z].w)))
+                         + P.elemMargin;
+        // Planar-DAT performs an exact rq query both before and after forward
+        // initialization. The global per-particle displacement cap makes the
+        // first query safe; the second query becomes the fixed color-solve
+        // neighborhood.
+        float pad = P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+            ? P.planarDATQueryRadius
+            : contactPad;
         lo = min(min(a, b), c) - float3(pad);
         hi = max(max(a, b), c) + float3(pad);
     } else {
         uint2 e = edges[gid - P.numTris];
         float3 a = posLin[e.x].xyz, b = posLin[e.y].xyz;
-        float pad = max(fabs(shape[e.x].w), fabs(shape[e.y].w)) + P.elemMargin;
+        float contactPad = max(fabs(shape[e.x].w), fabs(shape[e.y].w))
+                         + P.elemMargin;
+        float pad = P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+            ? P.planarDATQueryRadius
+            : contactPad;
         lo = min(a, b) - float3(pad);
         hi = max(a, b) + float3(pad);
     }
@@ -171,18 +186,39 @@ kernel void el_count(
     device const float4* shape      [[buffer(3)]],
     device atomic_uint* cellCount   [[buffer(4)]],
     constant SimParams& P           [[buffer(5)]],
+    device atomic_uint* counters    [[buffer(6)]],
     uint gid                        [[thread_position_in_grid]])
 {
     uint total = P.numTris + P.numEdges;
     if (gid >= total) return;
     float3 lo, hi;
     elemBounds(posLin, shape, tris, edges, P, gid, lo, hi);
+    if (P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+        && (!finite3(lo) || !finite3(hi))) {
+        atomic_fetch_add_explicit(&counters[CTR_DAT_INVALID_ANCHOR], 1u,
+                                  memory_order_relaxed);
+        return;
+    }
     int3 c0 = cellCoord(lo, P.elemCellSize);
-    int3 c1 = min(cellCoord(hi, P.elemCellSize), c0 + 2);
+    int3 rawC1 = cellCoord(hi, P.elemCellSize);
+    int maxSpan = P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+        ? 3 : 2;
+    if (P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+        && any(rawC1 - c0 > int3(maxSpan))) {
+        atomic_fetch_add_explicit(&counters[CTR_DAT_GRID_OVERFLOW], 1u,
+                                  memory_order_relaxed);
+    }
+    int3 c1 = min(rawC1, c0 + maxSpan);
+    uint seen[64];
+    uint seenCount = 0u;
     for (int z = c0.z; z <= c1.z; z++)
     for (int y = c0.y; y <= c1.y; y++)
     for (int x = c0.x; x <= c1.x; x++) {
         uint h = cellHash(int3(x, y, z), P.elemHashSize);
+        bool duplicate = false;
+        for (uint i = 0u; i < seenCount; ++i) duplicate = duplicate || seen[i] == h;
+        if (duplicate) continue;
+        seen[seenCount++] = h;
         atomic_fetch_add_explicit(&cellCount[h], 1u, memory_order_relaxed);
     }
 }
@@ -201,13 +237,23 @@ kernel void el_scatter(
     if (gid >= total) return;
     float3 lo, hi;
     elemBounds(posLin, shape, tris, edges, P, gid, lo, hi);
+    if (P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+        && (!finite3(lo) || !finite3(hi))) return;
     uint entry = gid < P.numTris ? gid : (ELEM_EDGE_BIT | (gid - P.numTris));
     int3 c0 = cellCoord(lo, P.elemCellSize);
-    int3 c1 = min(cellCoord(hi, P.elemCellSize), c0 + 2);
+    int maxSpan = P.surfaceTruncationMode == SURFACE_TRUNCATION_PLANAR_DAT
+        ? 3 : 2;
+    int3 c1 = min(cellCoord(hi, P.elemCellSize), c0 + maxSpan);
+    uint seen[64];
+    uint seenCount = 0u;
     for (int z = c0.z; z <= c1.z; z++)
     for (int y = c0.y; y <= c1.y; y++)
     for (int x = c0.x; x <= c1.x; x++) {
         uint h = cellHash(int3(x, y, z), P.elemHashSize);
+        bool duplicate = false;
+        for (uint i = 0u; i < seenCount; ++i) duplicate = duplicate || seen[i] == h;
+        if (duplicate) continue;
+        seen[seenCount++] = h;
         uint slot = atomic_fetch_add_explicit(&cellCursor[h], 1u, memory_order_relaxed);
         cellElems[slot] = entry;
     }
@@ -498,7 +544,8 @@ kernel void vt_emit(
                        max(fabs(shape[tid.y].w), fabs(shape[tid.z].w)));
         float hSum = rv + rt;
         float3 velT = (velLin[tid.x].xyz + velLin[tid.y].xyz + velLin[tid.z].xyz) / 3.0f;
-        float inflate = min(length(velV - velT) * P.dt, 0.3f * P.elemCellSize);
+        float inflate = min(length(velV - velT) * P.dt,
+                            0.3f * P.surfaceContactCellSize);
         float detect = hSum + P.elemMargin + inflate;
         if (dist2 > detect * detect) continue;
         float dist = sqrt(dist2);
@@ -753,7 +800,8 @@ kernel void ee_emit(
         float rB = max(fabs(shape[eB.x].w), fabs(shape[eB.y].w));
         float hSum = rA + rB;
         float3 velB = (velLin[eB.x].xyz + velLin[eB.y].xyz) * 0.5f;
-        float inflate = min(length(velA - velB) * P.dt, 0.3f * P.elemCellSize);
+        float inflate = min(length(velA - velB) * P.dt,
+                            0.3f * P.surfaceContactCellSize);
         if (dist - hSum > P.elemMargin + inflate) continue;
         if (dist < 1e-7f) continue;             // degenerate: let V-T handle
 

--- a/Sources/PhysicsAVBD/Shaders/27_planar_dat.metal
+++ b/Sources/PhysicsAVBD/Shaders/27_planar_dat.metal
@@ -1,0 +1,622 @@
+// Direction-aware Planar Divide-and-Truncate for deformable surface
+// vertex-triangle and edge-edge motion (arXiv:2604.15513). OGC remains the
+// contact force model; this replaces only its isotropic displacement bound.
+//
+// This is a clean Metal implementation informed by the paper and Newton's
+// Apache-2.0 VBD implementation. Important differences from Newton are a
+// compact global pair stream and fail-closed overflow handling.
+
+#define DAT_GEOMETRY_EPS 1.0e-8f
+#define DAT_TIME_MARGIN 1.0e-3f
+#define DAT_QUERY_THREADS 64u
+
+inline bool datCellInRange(int3 c, int3 lo, int3 hi) {
+    return all(c >= lo) && all(c <= hi);
+}
+
+inline void datAppendPair(device PlanarDATPairGPU* pairs,
+                          device atomic_uint* pairCounts,
+                          device atomic_uint* counters,
+                          constant SimParams& P,
+                          uint kind, uint owner, uint other,
+                          uint flags) {
+    uint slot = atomic_fetch_add_explicit(&pairCounts[0], 1u,
+                                           memory_order_relaxed);
+    atomic_fetch_add_explicit(&pairCounts[kind + 1u], 1u,
+                              memory_order_relaxed);
+    if (slot < P.maxPlanarDATPairs)
+        pairs[slot].data = uint4(kind, owner, other, flags);
+}
+
+// Exact V-T rq query. It runs at both the step-start and accepted predictor
+// poses. Between queries each particle moves at most R=0.5*gamma*rq, so a
+// pair omitted at the start (gap > rq) cannot cross before the second query.
+// Rechecking exact distance rejects hash aliases and keeps the stream compact.
+kernel void dat_build_vt_pairs(
+    device const float4* posLin      [[buffer(0)]],
+    device const uint* particleIdx   [[buffer(1)]],
+    device const uint4* tris         [[buffer(2)]],
+    device const uint2* edges        [[buffer(19)]],
+    device const uint* elemCellStart [[buffer(3)]],
+    device const uint* elemCellCount [[buffer(4)]],
+    device const uint* cellElems     [[buffer(5)]],
+    device const uint* nbrStart      [[buffer(6)]],
+    device const uint* nbrCount      [[buffer(7)]],
+    device const uint* nbrList       [[buffer(8)]],
+    device const float4* shape       [[buffer(9)]],
+    device const uint* clothGroup    [[buffer(10)]],
+    device const uint* clothVert     [[buffer(11)]],
+    device PlanarDATPairGPU* pairs   [[buffer(12)]],
+    device atomic_uint* pairCounts   [[buffer(13)]],
+    device atomic_uint* counters     [[buffer(14)]],
+    constant SimParams& P            [[buffer(15)]],
+    uint3 groupPosition              [[threadgroup_position_in_grid]],
+    uint lane                        [[thread_index_in_threadgroup]])
+{
+    uint gid = groupPosition.x;
+    if (gid >= P.numParticles) return;
+    uint v = particleIdx[gid];
+    float3 p = posLin[v].xyz;
+    if (!finite3(p)) {
+        if (lane == 0u) {
+            atomic_fetch_add_explicit(&counters[CTR_DAT_INVALID_ANCHOR], 1u,
+                                      memory_order_relaxed);
+        }
+        return;
+    }
+    int3 cell = cellCoord(p, P.elemCellSize);
+    uint h = cellHash(cell, P.elemHashSize);
+    uint s = elemCellStart[h], e = s + elemCellCount[h];
+    uint ns = nbrStart[v], ne = ns + nbrCount[v];
+    float query2 = P.planarDATQueryRadius * P.planarDATQueryRadius;
+
+    // One threadgroup owns a query vertex. Lanes cooperatively scan its hash
+    // bucket instead of serializing every candidate on one GPU thread.
+    for (uint k = s + lane; k < e; k += DAT_QUERY_THREADS) {
+        uint entry = cellElems[k];
+        if ((entry & ELEM_EDGE_BIT) != 0u || entry >= P.numTris) continue;
+        uint4 t = tris[entry];
+        if (t.x == v || t.y == v || t.z == v) continue;
+        if (nbrContains(nbrList, ns, ne, t.x)
+            || nbrContains(nbrList, ns, ne, t.y)
+            || nbrContains(nbrList, ns, ne, t.z)) continue;
+        float3 lo, hi;
+        elemBounds(posLin, shape, tris, edges, P, entry, lo, hi);
+        int3 tc0 = cellCoord(lo, P.elemCellSize);
+        int3 tc1 = min(cellCoord(hi, P.elemCellSize), tc0 + 3);
+        if (!datCellInRange(cell, tc0, tc1)) continue;
+        float3 bary;
+        float3 q = closestPtTriangle(p, posLin[t.x].xyz,
+                                     posLin[t.y].xyz,
+                                     posLin[t.z].xyz, bary);
+        float3 d = p - q;
+        if (dot(d, d) > query2) continue;
+        uint group = clothGroup[v];
+        bool sameSolid = group != 0u && clothVert[v] == 0u
+            && clothGroup[t.x] == group && clothGroup[t.y] == group
+            && clothGroup[t.z] == group
+            && clothVert[t.x] == 0u && clothVert[t.y] == 0u
+            && clothVert[t.z] == 0u;
+        uint flags = DAT_PAIR_TRUNCATE
+            | (sameSolid ? 0u : DAT_PAIR_CONTACT);
+        datAppendPair(pairs, pairCounts, counters, P,
+                      DAT_PAIR_VT, v, entry, flags);
+    }
+}
+
+// E-E uses the same exact rq neighborhood. A pair is owned by A<B and emitted only from the
+// minimum exact cell in tight(A) intersect expanded(B), eliminating multi-cell
+// and hash-alias duplicates without a per-thread candidate cap.
+kernel void dat_build_ee_pairs(
+    device const float4* posLin      [[buffer(0)]],
+    device const uint2* edges        [[buffer(1)]],
+    device const uint4* tris         [[buffer(2)]],
+    device const uint* elemCellStart [[buffer(3)]],
+    device const uint* elemCellCount [[buffer(4)]],
+    device const uint* cellElems     [[buffer(5)]],
+    device const uint* nbrStart      [[buffer(6)]],
+    device const uint* nbrCount      [[buffer(7)]],
+    device const uint* nbrList       [[buffer(8)]],
+    device const float4* shape       [[buffer(9)]],
+    device const uint* clothGroup    [[buffer(10)]],
+    device const uint* clothVert     [[buffer(11)]],
+    device PlanarDATPairGPU* pairs   [[buffer(12)]],
+    device atomic_uint* pairCounts   [[buffer(13)]],
+    device atomic_uint* counters     [[buffer(14)]],
+    constant SimParams& P            [[buffer(15)]],
+    uint3 groupPosition              [[threadgroup_position_in_grid]],
+    uint lane                        [[thread_index_in_threadgroup]])
+{
+    uint gid = groupPosition.x;
+    if (gid >= P.numEdges) return;
+    uint2 a = edges[gid];
+    float3 a0 = posLin[a.x].xyz, a1 = posLin[a.y].xyz;
+    if (!finite3(a0) || !finite3(a1)) {
+        if (lane == 0u) {
+            atomic_fetch_add_explicit(&counters[CTR_DAT_INVALID_ANCHOR], 1u,
+                                      memory_order_relaxed);
+        }
+        return;
+    }
+    int3 ac0 = cellCoord(min(a0, a1), P.elemCellSize);
+    int3 rawAC1 = cellCoord(max(a0, a1), P.elemCellSize);
+    if (lane == 0u && any(rawAC1 - ac0 > int3(3))) {
+        atomic_fetch_add_explicit(&counters[CTR_DAT_GRID_OVERFLOW], 1u,
+                                  memory_order_relaxed);
+    }
+    int3 ac1 = min(rawAC1, ac0 + 3);
+    uint ns0 = nbrStart[a.x], ne0 = ns0 + nbrCount[a.x];
+    uint ns1 = nbrStart[a.y], ne1 = ns1 + nbrCount[a.y];
+    float query2 = P.planarDATQueryRadius * P.planarDATQueryRadius;
+
+    for (int z = ac0.z; z <= ac1.z; ++z)
+    for (int y = ac0.y; y <= ac1.y; ++y)
+    for (int x = ac0.x; x <= ac1.x; ++x) {
+        int3 cell = int3(x, y, z);
+        uint h = cellHash(cell, P.elemHashSize);
+        uint s = elemCellStart[h], e = s + elemCellCount[h];
+        // All lanes visit the same exact A cell and split its candidate
+        // bucket. Canonical overlap-cell ownership still emits each pair once.
+        for (uint k = s + lane; k < e; k += DAT_QUERY_THREADS) {
+            uint entry = cellElems[k];
+            if ((entry & ELEM_EDGE_BIT) == 0u) continue;
+            uint other = entry & ~ELEM_EDGE_BIT;
+            if (other <= gid || other >= P.numEdges) continue;
+            uint2 b = edges[other];
+            if (b.x == a.x || b.x == a.y || b.y == a.x || b.y == a.y)
+                continue;
+            if (nbrContains(nbrList, ns0, ne0, b.x)
+                || nbrContains(nbrList, ns0, ne0, b.y)
+                || nbrContains(nbrList, ns1, ne1, b.x)
+                || nbrContains(nbrList, ns1, ne1, b.y)) continue;
+            float3 blo, bhi;
+            elemBounds(posLin, shape, tris, edges, P,
+                       P.numTris + other, blo, bhi);
+            int3 bc0 = cellCoord(blo, P.elemCellSize);
+            int3 bc1 = min(cellCoord(bhi, P.elemCellSize), bc0 + 3);
+            int3 overlap0 = max(ac0, bc0);
+            int3 overlap1 = min(ac1, bc1);
+            if (any(overlap0 > overlap1) || any(cell != overlap0)) continue;
+
+            float sb, tb;
+            float3 b0 = posLin[b.x].xyz, b1 = posLin[b.y].xyz;
+            eeClosestSegSeg(a0, a1, b0, b1, sb, tb);
+            float3 ca = mix(a0, a1, sb), cb = mix(b0, b1, tb);
+            float3 d = ca - cb;
+            if (dot(d, d) > query2) continue;
+            uint group = clothGroup[a.x];
+            bool sameSolid = group != 0u
+                && clothGroup[a.y] == group
+                && clothGroup[b.x] == group && clothGroup[b.y] == group
+                && clothVert[a.x] == 0u && clothVert[a.y] == 0u
+                && clothVert[b.x] == 0u && clothVert[b.y] == 0u;
+            uint flags = DAT_PAIR_TRUNCATE;
+            if (!sameSolid && gid < P.numSurfaceContactEdges
+                && other < P.numSurfaceContactEdges) {
+                flags |= DAT_PAIR_CONTACT;
+            }
+            datAppendPair(pairs, pairCounts, counters, P,
+                          DAT_PAIR_EE, gid, other, flags);
+        }
+    }
+}
+
+kernel void dat_finalize_pairs(
+    device const atomic_uint* pairCounts [[buffer(0)]],
+    device atomic_uint* counters         [[buffer(1)]],
+    device uint* args                     [[buffer(2)]],
+    constant SimParams& P                [[buffer(3)]],
+    uint gid                             [[thread_position_in_grid]])
+{
+    if (gid != 0u) return;
+    uint total = atomic_load_explicit(&pairCounts[0], memory_order_relaxed);
+    uint vt = atomic_load_explicit(&pairCounts[1], memory_order_relaxed);
+    uint ee = atomic_load_explicit(&pairCounts[2], memory_order_relaxed);
+    atomic_fetch_max_explicit(&counters[CTR_DAT_PAIRS], total,
+                              memory_order_relaxed);
+    atomic_fetch_max_explicit(&counters[CTR_DAT_VT_PAIRS], vt,
+                              memory_order_relaxed);
+    atomic_fetch_max_explicit(&counters[CTR_DAT_EE_PAIRS], ee,
+                              memory_order_relaxed);
+    uint stored = min(total, P.maxPlanarDATPairs);
+    args[0] = (stored + 63u) / 64u;
+    args[1] = 1u;
+    args[2] = 1u;
+}
+
+// Pair-parallel OGC contact emission. This uses the exact same full nearby
+// pair stream as DAT rather than the old best-four tracker.
+kernel void dat_emit_contacts(
+    device const PlanarDATPairGPU* pairs [[buffer(0)]],
+    device const float4* posLin          [[buffer(1)]],
+    device const float4* shape           [[buffer(2)]],
+    device const float4* props           [[buffer(3)]],
+    device const float4* velLin          [[buffer(4)]],
+    device const uint4* tris             [[buffer(5)]],
+    device const uint2* edges            [[buffer(6)]],
+    device SoftContactGPU* soft          [[buffer(7)]],
+    device atomic_uint* counters         [[buffer(8)]],
+    device const SoftContactGPU* prevSoft [[buffer(9)]],
+    device const atomic_uint* mapKeyA    [[buffer(10)]],
+    device const uint* mapKeyB           [[buffer(11)]],
+    device const uint* mapVal            [[buffer(12)]],
+    constant SimParams& P                [[buffer(13)]],
+    device const atomic_uint* pairCounts [[buffer(14)]],
+    device const float4* massState        [[buffer(15)]],
+    device const float4* referencePos     [[buffer(16)]],
+    uint gid                             [[thread_position_in_grid]])
+{
+    uint count = min(atomic_load_explicit(&pairCounts[0],
+                                           memory_order_relaxed),
+                     P.maxPlanarDATPairs);
+    if (gid >= count) return;
+    uint4 pair = pairs[gid].data;
+    if ((pair.w & DAT_PAIR_CONTACT) == 0u) return;
+    if (pair.x == DAT_PAIR_VT) {
+        uint v = pair.y, ti = pair.z;
+        if (ti >= P.numTris) return;
+        uint4 t = tris[ti];
+        float3 p = posLin[v].xyz;
+        float3 a = posLin[t.x].xyz, b = posLin[t.y].xyz,
+               c = posLin[t.z].xyz;
+        float3 bary;
+        float3 q = closestPtTriangle(p, a, b, c, bary);
+        float3 d = p - q;
+        float dist2 = dot(d, d);
+        float rv = fabs(shape[v].w);
+        float rt = max(fabs(shape[t.x].w),
+                       max(fabs(shape[t.y].w), fabs(shape[t.z].w)));
+        float hSum = rv + rt;
+        float3 velT = (velLin[t.x].xyz + velLin[t.y].xyz
+                       + velLin[t.z].xyz) / 3.0f;
+        float inflate = min(length(velLin[v].xyz - velT) * P.dt,
+                            0.3f * P.surfaceContactCellSize);
+        // The shared safety stream is complete only through rq. Never let
+        // speculative force inflation claim a wider contact band than the
+        // candidate source that feeds it.
+        float detect = min(hSum + P.elemMargin + inflate,
+                           P.planarDATQueryRadius);
+        if (dist2 > detect * detect) return;
+        float dist = sqrt(dist2);
+        float3 triN = cross(b - a, c - a);
+        float nl = length(triN);
+        if (nl < DAT_GEOMETRY_EPS) return;
+        triN /= nl;
+        float side = dot(d, triN) >= 0.0f ? 1.0f : -1.0f;
+        uint keyA = (SC_VT << 28) | v;
+        uint keyB = ti;
+        bool interior = bary.x > 0.02f && bary.y > 0.02f
+                     && bary.z > 0.02f;
+        float remembered = interior
+            ? softPrevSide(prevSoft, mapKeyA, mapKeyB, mapVal, P,
+                           keyA, keyB, side) : side;
+        float3 n;
+        float gap;
+        if (dist > 1.0e-7f && side == remembered) {
+            n = d / dist;
+            gap = dist;
+        } else {
+            n = remembered * triN;
+            gap = -dist;
+        }
+        float fricT = props[t.x].w * bary.x + props[t.y].w * bary.y
+                    + props[t.z].w * bary.z;
+        float friction = sqrt(max(props[v].w * fricT, 0.0f));
+        float minMass = massState[v].w > 0.0f ? massState[v].w : FLT_MAX;
+        uint4 ids = uint4(v, t.x, t.y, t.z);
+        for (int j = 1; j < 4; ++j) {
+            float m = massState[ids[j]].w;
+            if (m > 0.0f) minMass = min(minMass, m);
+        }
+        if (minMass == FLT_MAX) return;
+        float3 dq = (p - referencePos[v].xyz)
+            - bary.x * (a - referencePos[t.x].xyz)
+            - bary.y * (b - referencePos[t.y].xyz)
+            - bary.z * (c - referencePos[t.z].xyz);
+        float Cdetect = gap - hSum + P.elemMargin;
+        float C0n = Cdetect - dot(n, dq);
+        softEmit(soft, counters, prevSoft, mapKeyA, mapKeyB, mapVal, P,
+                 ids, float4(1.0f, -bary.x, -bary.y, -bary.z),
+                 n, friction, float3(0), C0n,
+                 hSum - P.elemMargin, softLambdaCap(P, minMass), minMass,
+                 SC_VT, false, false, remembered < 0.0f, keyA, keyB);
+        return;
+    }
+
+    uint ea = pair.y, eb = pair.z;
+    if (ea >= P.numEdges || eb >= P.numEdges) return;
+    uint2 aIds = edges[ea], bIds = edges[eb];
+    float3 a0 = posLin[aIds.x].xyz, a1 = posLin[aIds.y].xyz;
+    float3 b0 = posLin[bIds.x].xyz, b1 = posLin[bIds.y].xyz;
+    float s, t;
+    eeClosestSegSeg(a0, a1, b0, b1, s, t);
+    if (s < EE_INTERIOR_EPS || s > 1.0f - EE_INTERIOR_EPS
+        || t < EE_INTERIOR_EPS || t > 1.0f - EE_INTERIOR_EPS) return;
+    float3 ca = a0 + (a1 - a0) * s;
+    float3 cb = b0 + (b1 - b0) * t;
+    float3 d = ca - cb;
+    float dist = length(d);
+    if (dist < 1.0e-7f) return;
+    float rA = max(fabs(shape[aIds.x].w), fabs(shape[aIds.y].w));
+    float rB = max(fabs(shape[bIds.x].w), fabs(shape[bIds.y].w));
+    float hSum = rA + rB;
+    float3 va = (velLin[aIds.x].xyz + velLin[aIds.y].xyz) * 0.5f;
+    float3 vb = (velLin[bIds.x].xyz + velLin[bIds.y].xyz) * 0.5f;
+    float inflate = min(length(va - vb) * P.dt,
+                        0.3f * P.surfaceContactCellSize);
+    float detect = min(hSum + P.elemMargin + inflate,
+                       P.planarDATQueryRadius);
+    if (dist > detect) return;
+    float3 nGeo = d / dist;
+    uint keyA = (SC_EE << 28) | ea;
+    uint keyB = eb;
+    float3 n = nGeo;
+    float gap = dist;
+    int previous = softMapFind(mapKeyA, mapKeyB, mapVal,
+                               P.softMapCapacity, keyA, keyB);
+    if (previous >= 0 && dot(nGeo, prevSoft[previous].normal.xyz) < 0.0f) {
+        n = -nGeo;
+        gap = -dist;
+    }
+    float friction = sqrt(max(
+        (props[aIds.x].w + props[aIds.y].w) * 0.5f
+        * (props[bIds.x].w + props[bIds.y].w) * 0.5f, 0.0f));
+    float minMass = FLT_MAX;
+    uint4 ids = uint4(aIds.x, aIds.y, bIds.x, bIds.y);
+    for (int j = 0; j < 4; ++j) {
+        float m = massState[ids[j]].w;
+        if (m > 0.0f) minMass = min(minMass, m);
+    }
+    if (minMass == FLT_MAX) return;
+    float3 dq = (1.0f - s) * (a0 - referencePos[aIds.x].xyz)
+              + s * (a1 - referencePos[aIds.y].xyz)
+              - (1.0f - t) * (b0 - referencePos[bIds.x].xyz)
+              - t * (b1 - referencePos[bIds.y].xyz);
+    float Cdetect = gap - hSum + P.elemMargin;
+    float C0n = Cdetect - dot(n, dq);
+    softEmit(soft, counters, prevSoft, mapKeyA, mapKeyB, mapVal, P,
+             ids, float4(1.0f - s, s, -(1.0f - t), -t), n, friction,
+             float3(0), C0n,
+             hSum - P.elemMargin, softLambdaCap(P, minMass), minMass,
+             SC_EE, false, false, false, keyA, keyB);
+}
+
+kernel void dat_clear_pair_counts(device atomic_uint* counts [[buffer(0)]],
+                                  uint gid [[thread_position_in_grid]]) {
+    if (gid < 3u) atomic_store_explicit(&counts[gid], 0u,
+                                        memory_order_relaxed);
+}
+
+kernel void dat_clear_element_grid(device atomic_uint* counts [[buffer(0)]],
+                                   constant SimParams& P [[buffer(1)]],
+                                   uint gid [[thread_position_in_grid]]) {
+    if (gid >= P.elemHashSize) return;
+    atomic_store_explicit(&counts[gid], 0u, memory_order_relaxed);
+}
+
+kernel void dat_reanchor(device const float4* posLin [[buffer(0)]],
+                         device const uint* particleIdx [[buffer(1)]],
+                         device float4* anchor [[buffer(2)]],
+                         constant SimParams& P [[buffer(3)]],
+                         uint gid [[thread_position_in_grid]]) {
+    if (gid < P.numParticles) {
+        uint v = particleIdx[gid];
+        anchor[v] = float4(posLin[v].xyz, 0.0f);
+    }
+}
+
+inline void datAtomicT(device atomic_uint* truncBits, uint vertexID,
+                       float3 x, float3 dx, float3 n, float3 plane,
+                       float side, float gamma) {
+    float s0 = side * dot(n, x - plane);
+    float q = side * dot(n, dx);
+    // Tolerances must be translation invariant. Scaling by |x| makes a
+    // scene far from the world origin classify millimetre motion as parallel
+    // and can miss a genuine crossing.
+    if (!finite_bits(s0) || !finite_bits(q)) return;
+    if (s0 < -DAT_GEOMETRY_EPS) {
+        atomic_fetch_min_explicit(&truncBits[vertexID], as_type<uint>(0.0f),
+                                  memory_order_relaxed);
+        return;
+    }
+    // A generic "parallel" epsilon must not hide an observed sign change:
+    // even sub-micron motion is constrained when its endpoint crosses.
+    if (q >= 0.0f || s0 + q > 0.0f) return;
+    float hit = max(s0, 0.0f) / (-q);
+    if (hit > 1.0f + DAT_GEOMETRY_EPS) return;
+    float t = clamp(min(gamma * hit, hit - DAT_TIME_MARGIN), 0.0f, 1.0f);
+    atomic_fetch_min_explicit(&truncBits[vertexID], as_type<uint>(t),
+                              memory_order_relaxed);
+}
+
+kernel void dat_reduce(
+    device const PlanarDATPairGPU* pairs [[buffer(0)]],
+    device const float4* posLin          [[buffer(1)]],
+    device const float4* anchor          [[buffer(2)]],
+    device const uint4* tris             [[buffer(3)]],
+    device const uint2* edges            [[buffer(4)]],
+    device atomic_uint* truncBits        [[buffer(5)]],
+    device const atomic_uint* pairCounts [[buffer(6)]],
+    constant SimParams& P                [[buffer(7)]],
+    device atomic_uint* counters         [[buffer(8)]],
+    uint gid                             [[thread_position_in_grid]])
+{
+    uint count = min(atomic_load_explicit(&pairCounts[0],
+                                           memory_order_relaxed),
+                     P.maxPlanarDATPairs);
+    if (gid >= count) return;
+    uint4 pair = pairs[gid].data;
+    if ((pair.w & DAT_PAIR_TRUNCATE) == 0u) return;
+    if (pair.x == DAT_PAIR_VT) {
+        uint v = pair.y;
+        uint4 t = tris[pair.z];
+        float3 xv = anchor[v].xyz;
+        float3 a = anchor[t.x].xyz, b = anchor[t.y].xyz,
+               c = anchor[t.z].xyz;
+        float3 bary;
+        float3 cp = closestPtTriangle(xv, a, b, c, bary);
+        float3 nh = xv - cp;
+        float gap = length(nh);
+        if (!finite_bits(gap) || gap < DAT_GEOMETRY_EPS) {
+            atomic_fetch_add_explicit(&counters[CTR_DAT_INVALID_ANCHOR], 1u,
+                                      memory_order_relaxed);
+            atomic_fetch_min_explicit(&truncBits[v], as_type<uint>(0.0f),
+                                      memory_order_relaxed);
+            atomic_fetch_min_explicit(&truncBits[t.x], as_type<uint>(0.0f),
+                                      memory_order_relaxed);
+            atomic_fetch_min_explicit(&truncBits[t.y], as_type<uint>(0.0f),
+                                      memory_order_relaxed);
+            atomic_fetch_min_explicit(&truncBits[t.z], as_type<uint>(0.0f),
+                                      memory_order_relaxed);
+            return;
+        }
+        if (gap > P.planarDATQueryRadius) return;
+        float3 n = nh / gap;
+        float3 dv = posLin[v].xyz - xv;
+        float3 da = posLin[t.x].xyz - a;
+        float3 db = posLin[t.y].xyz - b;
+        float3 dc = posLin[t.z].xyz - c;
+        float approachV = max(-dot(n, dv), 0.0f);
+        float approachT = max(max(dot(n, da), dot(n, db)),
+                              max(dot(n, dc), 0.0f));
+        float lambda = approachV + approachT == 0.0f ? 0.5f
+            : clamp(approachT / (approachV + approachT), 0.05f, 0.95f);
+        float3 plane = cp + lambda * nh;
+        if (approachV > 0.0f)
+            datAtomicT(truncBits, v, xv, dv, n, plane, 1.0f,
+                       P.planarDATRelaxation);
+        if (approachT > 0.0f) {
+            datAtomicT(truncBits, t.x, a, da, n, plane, -1.0f,
+                       P.planarDATRelaxation);
+            datAtomicT(truncBits, t.y, b, db, n, plane, -1.0f,
+                       P.planarDATRelaxation);
+            datAtomicT(truncBits, t.z, c, dc, n, plane, -1.0f,
+                       P.planarDATRelaxation);
+        }
+        return;
+    }
+
+    uint2 ea = edges[pair.y], eb = edges[pair.z];
+    float3 a0 = anchor[ea.x].xyz, a1 = anchor[ea.y].xyz;
+    float3 b0 = anchor[eb.x].xyz, b1 = anchor[eb.y].xyz;
+    float s, t;
+    eeClosestSegSeg(a0, a1, b0, b1, s, t);
+    float3 ca = a0 + (a1 - a0) * s;
+    float3 cb = b0 + (b1 - b0) * t;
+    float3 nh = ca - cb;
+    float gap = length(nh);
+    if (!finite_bits(gap) || gap <= DAT_GEOMETRY_EPS) {
+        atomic_fetch_add_explicit(&counters[CTR_DAT_INVALID_ANCHOR], 1u,
+                                  memory_order_relaxed);
+        atomic_fetch_min_explicit(&truncBits[ea.x], as_type<uint>(0.0f),
+                                  memory_order_relaxed);
+        atomic_fetch_min_explicit(&truncBits[ea.y], as_type<uint>(0.0f),
+                                  memory_order_relaxed);
+        atomic_fetch_min_explicit(&truncBits[eb.x], as_type<uint>(0.0f),
+                                  memory_order_relaxed);
+        atomic_fetch_min_explicit(&truncBits[eb.y], as_type<uint>(0.0f),
+                                  memory_order_relaxed);
+        return;
+    }
+    if (gap > P.planarDATQueryRadius) return;
+    float3 n = nh / gap;
+    float3 da0 = posLin[ea.x].xyz - a0;
+    float3 da1 = posLin[ea.y].xyz - a1;
+    float3 db0 = posLin[eb.x].xyz - b0;
+    float3 db1 = posLin[eb.y].xyz - b1;
+    float approachA = max(max(-dot(n, da0), -dot(n, da1)), 0.0f);
+    float approachB = max(max(dot(n, db0), dot(n, db1)), 0.0f);
+    float lambda = approachA + approachB == 0.0f ? 0.5f
+        : clamp(approachB / (approachA + approachB), 0.05f, 0.95f);
+    float3 plane = cb + lambda * nh;
+    if (approachA > 0.0f) {
+        datAtomicT(truncBits, ea.x, a0, da0, n, plane, 1.0f,
+                   P.planarDATRelaxation);
+        datAtomicT(truncBits, ea.y, a1, da1, n, plane, 1.0f,
+                   P.planarDATRelaxation);
+    }
+    if (approachB > 0.0f) {
+        datAtomicT(truncBits, eb.x, b0, db0, n, plane, -1.0f,
+                   P.planarDATRelaxation);
+        datAtomicT(truncBits, eb.y, b1, db1, n, plane, -1.0f,
+                   P.planarDATRelaxation);
+    }
+}
+
+kernel void dat_apply(
+    device float4* posLin             [[buffer(0)]],
+    device const float4* anchor       [[buffer(1)]],
+    device const uint* particleIdx    [[buffer(2)]],
+    device atomic_uint* truncBits     [[buffer(3)]],
+    device const atomic_uint* pairCounts [[buffer(4)]],
+    device atomic_uint* counters      [[buffer(5)]],
+    constant SimParams& P             [[buffer(6)]],
+    uint gid                          [[thread_position_in_grid]])
+{
+    if (gid >= P.numParticles) return;
+    uint v = particleIdx[gid];
+    float4 current = posLin[v];
+    float3 d = current.xyz - anchor[v].xyz;
+    uint raw = atomic_load_explicit(&pairCounts[0], memory_order_relaxed);
+    bool unsafeCapacity = raw > P.maxPlanarDATPairs
+        || atomic_load_explicit(&counters[CTR_DAT_PAIRS],
+                                memory_order_relaxed) > P.maxPlanarDATPairs
+        || atomic_load_explicit(&counters[CTR_DAT_GRID_OVERFLOW],
+                                memory_order_relaxed) > 0u
+        || atomic_load_explicit(&counters[CTR_DAT_INVALID_ANCHOR],
+                                memory_order_relaxed) > 0u;
+    // Consume and reset in one atomic operation. Dispatch ordering guarantees
+    // that every pair reduction has completed first, and leaving 1.0 behind
+    // prepares the next color without a separate full-particle clear pass.
+    float reducedT = as_type<float>(atomic_exchange_explicit(
+        &truncBits[v], as_type<uint>(1.0f), memory_order_relaxed));
+    float t = unsafeCapacity ? 0.0f : reducedT;
+    if (!finite3(d) || !finite_bits(t)) {
+        atomic_fetch_add_explicit(&counters[CTR_DAT_INVALID_ANCHOR], 1u,
+                                  memory_order_relaxed);
+        d = float3(0.0f);
+        t = 0.0f;
+    }
+    bool truncated = t < 1.0f;
+    d *= clamp(t, 0.0f, 1.0f);
+    float maxD = 0.5f * P.planarDATRelaxation * P.planarDATQueryRadius;
+    float d2 = dot(d, d);
+    if (d2 > maxD * maxD) {
+        d *= maxD * rsqrt(d2);
+        truncated = true;
+    }
+    if (truncated) {
+        posLin[v] = float4(anchor[v].xyz + d, current.w);
+        atomic_fetch_add_explicit(&counters[CTR_DAT_TRUNCATIONS], 1u,
+                                  memory_order_relaxed);
+    }
+}
+
+// A soft-contact capacity failure is terminal, but it is discovered on the
+// GPU before retirement. Restore the whole deformable surface to the exact
+// step-start pose so a clipped contact set is never externally published as a
+// partially solved frame. finalize_velocities then produces zero surface
+// velocity for the failed step.
+kernel void dat_restore_failed_surface(
+    device float4* posLin                  [[buffer(0)]],
+    device const float4* initLin           [[buffer(1)]],
+    device const uint* particleIdx         [[buffer(2)]],
+    device const atomic_uint* counters     [[buffer(3)]],
+    constant SimParams& P                  [[buffer(4)]],
+    uint gid                               [[thread_position_in_grid]])
+{
+    if (gid >= P.numParticles) return;
+    uint rawSoft = atomic_load_explicit(&counters[CTR_SOFT_CANDIDATES],
+                                        memory_order_relaxed);
+    bool failed = rawSoft > P.maxSoft
+        || atomic_load_explicit(&counters[CTR_DAT_PAIRS],
+                                memory_order_relaxed) > P.maxPlanarDATPairs
+        || atomic_load_explicit(&counters[CTR_DAT_GRID_OVERFLOW],
+                                memory_order_relaxed) > 0u
+        || atomic_load_explicit(&counters[CTR_DAT_INVALID_ANCHOR],
+                                memory_order_relaxed) > 0u;
+    if (failed) {
+        uint v = particleIdx[gid];
+        posLin[v] = float4(initLin[v].xyz, posLin[v].w);
+    }
+}

--- a/Sources/PhysicsAVBD/Shaders/40_solver.metal
+++ b/Sources/PhysicsAVBD/Shaders/40_solver.metal
@@ -612,7 +612,7 @@ kernel void warmstart_bodies(
     constant SimParams& P           [[buffer(9)]],
     device float4* ogcPrev          [[buffer(10)]],
     device const uint* boundsBits   [[buffer(11)]],
-    constant uint& doOgc            [[buffer(12)]],
+    constant uint& truncationMode   [[buffer(12)]],
     device const float4* shapeW     [[buffer(13)]],
     device const float* gravityScale [[buffer(14)]],
     uint gid                        [[thread_position_in_grid]])
@@ -640,14 +640,19 @@ kernel void warmstart_bodies(
 
     initLin[gid] = float4(pl.xyz, 0);
     initAng[gid] = pa;
+    // The committed collision-query pose is required for every surface
+    // vertex, including mass-zero pins referenced by a moving triangle.
+    if (truncationMode != 0u && shapeW[gid].w < 0.0f) {
+        ogcPrev[gid] = float4(pl.xyz, 0);
+    }
     if (mass > 0.0f) {
         float3 guess = pl.xyz + vl * dt
                      + float3(0, 0, bodyGravity) * (accelWeight * dt * dt);
         // OGC anchor = the detection pose; the warmstart placement itself
         // is truncated within the bound (paper Eq 28) so the step STARTS
         // penetration-free — the in-loop refresh grants further budget
-        if (doOgc != 0u && shapeW[gid].w < 0.0f) {
-            ogcPrev[gid] = float4(pl.xyz, 0);
+        if (truncationMode == SURFACE_TRUNCATION_ISOTROPIC
+            && shapeW[gid].w < 0.0f) {
             float d2 = as_type<float>(boundsBits[gid]);
             if (d2 < 1e37f) {
                 float bv = max(0.45f * sqrt(d2), -0.2f * shapeW[gid].w);
@@ -1529,7 +1534,8 @@ kernel void primal_particles_split(
     float maxLin = 0.35f * fabs(shape[body].w);
     float lin2 = dot(dxLin, dxLin);
     if (lin2 > maxLin * maxLin) dxLin *= maxLin * rsqrt(lin2);
-    if (!rigid && P.numTris > 0u) {         // soft-surface particles only
+    if (!rigid && P.numTris > 0u
+        && P.surfaceTruncationMode == SURFACE_TRUNCATION_ISOTROPIC) {
         dxLin = ogcTruncate(dxLin, pl.xyz, ogcPrev[body].xyz,
                             boundsBits[body], -shape[body].w, ogcCounters);
     }

--- a/Sources/avbd/main.swift
+++ b/Sources/avbd/main.swift
@@ -12,7 +12,9 @@ import simd
 // Usage:
 //   avbd run <demo> [--frames N] [--iterations N] [--cpu] [--json] [--scale N]
 //            [--dt T] [--watch BODY] [--stats-every N]
+//            [--truncation planar|isotropic]
 //   avbd bench <demo> [--frames N] [--scale N] [--iterations N]
+//            [--truncation planar|isotropic]
 //   avbd list
 //   avbd parity <demo> [--frames N]
 
@@ -100,6 +102,16 @@ struct Options {
     var gaitSwingHeight: Float = 0.016
     var gaitPlacementHorizon: Float = 0.35
     var gaitMaximumPlacement: Float = 0.045
+    var surfaceTruncationMode: GPUSolver.SurfaceTruncationMode = .planarDAT
+}
+
+private func truncationName(
+    _ mode: GPUSolver.SurfaceTruncationMode
+) -> String {
+    switch mode {
+    case .planarDAT: return "planar"
+    case .isotropicDAT: return "isotropic"
+    }
 }
 
 /// Reads the action trajectory from either a probe or physical-flow artifact
@@ -999,6 +1011,12 @@ func parseOptions(
         case "--iterations": o.iterations = integer(after: args[i])
         case "--scale": o.scale = integer(after: args[i]) ?? o.scale
         case "--dt": o.dt = float(after: args[i])
+        case "--truncation":
+            switch value(after: args[i]) {
+            case "planar": o.surfaceTruncationMode = .planarDAT
+            case "isotropic": o.surfaceTruncationMode = .isotropicDAT
+            default: fail("--truncation must be planar or isotropic")
+            }
         case "--cpu": o.useCPU = true
         case "--json": o.json = true
         case "--watch": o.watch = integer(after: args[i])
@@ -4144,6 +4162,7 @@ case "run":
         }
     } else {
         let solver = try GPUSolver(scene: scene)
+        solver.surfaceTruncationMode = o.surfaceTruncationMode
         let t0 = Date()
         for f in 0..<o.frames {
             try solver.submitStep()
@@ -4188,6 +4207,7 @@ case "rodexp":
         scene.settings.rodDecayPow = decay
         if let it = o.iterations { scene.settings.iterations = it }
         let solver = try GPUSolver(scene: scene)
+        solver.surfaceTruncationMode = o.surfaceTruncationMode
         var windowMax: [Float] = []
         var cur: Float = 0
         var worstStretch: Float = 0
@@ -4228,7 +4248,8 @@ case "profile":
     let o = parseOptions(Array(args.dropFirst(2)))
     let scene = makeScene(args[1], o)
     let solver = try GPUSolver(scene: scene)
-    print("bodies \(scene.bodies.count)  tris \(scene.tris.count)+\(solver.tetBoundaryTris.count)b  springs \(scene.springs.count)  joints \(scene.joints.count)  colors \(solver.staticUsedColors)  persistent-capacity \(solver.persistentCapacity)")
+    solver.surfaceTruncationMode = o.surfaceTruncationMode
+    print("truncation \(truncationName(o.surfaceTruncationMode))  bodies \(scene.bodies.count)  tris \(scene.tris.count)+\(solver.tetBoundaryTris.count)b  springs \(scene.springs.count)  joints \(scene.joints.count)  colors \(solver.staticUsedColors)  persistent-capacity \(solver.persistentCapacity)")
     for _ in 0..<30 { try solver.submitStep() } // warm up
     try solver.synchronize()
     solver.profiling = true
@@ -4245,6 +4266,10 @@ case "profile":
         print(String(format: "  %-22s %8.3f ms  %5.1f%%", (name as NSString).utf8String!,
                      ms, ns / total * 100))
     }
+    print("DAT pairs \(solver.lastPlanarDATPairs) "
+        + "(VT \(solver.lastPlanarDATVertexTrianglePairs), "
+        + "EE \(solver.lastPlanarDATEdgeEdgePairs))  "
+        + "truncations \(solver.lastPlanarDATTruncations)")
 
 case "clothgate":
     // Cloth gate runner: step a demo and report element-contact metrics
@@ -4253,7 +4278,8 @@ case "clothgate":
     let o = parseOptions(Array(args.dropFirst(2)))
     let scene = makeScene(args[1], o)
     let solver = try GPUSolver(scene: scene)
-    print("bodies \(scene.bodies.count)  tris \(scene.tris.count)  persistent-capacity \(solver.persistentCapacity)")
+    solver.surfaceTruncationMode = o.surfaceTruncationMode
+    print("truncation \(truncationName(o.surfaceTruncationMode))  bodies \(scene.bodies.count)  tris \(scene.tris.count)  persistent-capacity \(solver.persistentCapacity)")
     var worstGap: Float = .greatestFiniteMagnitude
     var worstStretch: Float = 0
     var ke: Float = 0
@@ -4293,8 +4319,11 @@ case "clothgate":
                 worstGap = min(worstGap, gap)
                 worstStretch = max(worstStretch, stretch)
             }
-            print(String(format: "frame %5d  gap %+.4f  stretch %.4f  soft %5d  pairs %5d  KE %.4f%@",
-                         f + 1, gap, stretch, solver.lastNumSoft, solver.lastNumPairs, ke, loc))
+            print(String(format: "frame %5d  gap %+.4f  stretch %.4f  soft %5d  pairs %5d  DAT %5d/%5d  trunc %5d  KE %.4f%@",
+                         f + 1, gap, stretch, solver.lastNumSoft,
+                         solver.lastNumPairs, solver.lastPlanarDATVertexTrianglePairs,
+                         solver.lastPlanarDATEdgeEdgePairs,
+                         solver.lastPlanarDATTruncations, ke, loc))
         }
     }
     print(String(format: "settled-half: worstGap %+.4f  worstStretch %.4f",
@@ -4398,8 +4427,10 @@ case "bench":
     let o = parseOptions(Array(args.dropFirst(2)))
     let scene = makeScene(args[1], o)
     let solver = try GPUSolver(scene: scene)
+    solver.surfaceTruncationMode = o.surfaceTruncationMode
     // warmup
     for _ in 0..<10 { try solver.submitStep() }
+    try solver.synchronize()
     if args.contains("--capture") {
         let mgr = MTLCaptureManager.shared()
         let cd = MTLCaptureDescriptor()
@@ -4428,6 +4459,11 @@ case "bench":
     print(String(format: "  cpu encode: %.3f ms/frame", encodeS * 1000 / Double(o.frames)))
     print(String(format: "%@: %d bodies, %d iterations, %.3f ms/frame (%.1f FPS)",
                  scene.name, scene.bodies.count, scene.settings.iterations, ms, 1000 / ms))
+    print("  truncation \(truncationName(o.surfaceTruncationMode)); "
+        + "DAT pairs \(solver.lastPlanarDATPairs) "
+        + "(VT \(solver.lastPlanarDATVertexTrianglePairs), "
+        + "EE \(solver.lastPlanarDATEdgeEdgePairs)); "
+        + "truncations \(solver.lastPlanarDATTruncations)")
     if solver.profiling, solver.profileFrames > 0 {
         let n = Double(solver.profileFrames)
         let total = solver.profileNS.values.reduce(0, +)
@@ -4448,6 +4484,7 @@ case "parity":
     let scene = makeScene(args[1], o)
     let cpu = scene.makeCPUSolver()
     let gpu = try GPUSolver(scene: scene)
+    gpu.surfaceTruncationMode = o.surfaceTruncationMode
     var maxDiff: Float = 0
     for f in 0..<o.frames {
         cpu.step()

--- a/Tests/PhysicsAVBDTests/ClothTests.swift
+++ b/Tests/PhysicsAVBDTests/ClothTests.swift
@@ -63,9 +63,10 @@ final class ClothTests: XCTestCase {
             scene.joints[i].rA
         }
         // Pass-through detector: a B node whose closest point on an A
-        // triangle is INTERIOR and on the wrong (under) side, deeper than
-        // half the skin, has gone through the strip. Hanging next to A's
-        // edges resolves to boundary closest points and doesn't count.
+        // triangle is INTERIOR and on the wrong (under) side has crossed the
+        // oriented sheet. Sample every accepted frame: unsigned final gaps or
+        // sparse sampling can miss a cross-and-return trajectory. Hanging next
+        // to A's edges resolves to boundary closest points and doesn't count.
         let aSet = Set(aNodes)
         let aTris = scene.tris.filter {
             aSet.contains($0.ids.0) && aSet.contains($0.ids.1) && aSet.contains($0.ids.2)
@@ -78,7 +79,6 @@ final class ClothTests: XCTestCase {
                 gpu.setJointWorldAnchor(j, point: anchors[k])
             }
             gpu.step()
-            if f % 5 != 0 { continue }
             for b in bNodes {
                 let p = gpu.bodyPosition(b)
                 guard abs(p.x) < 1.0 && abs(p.y) < 0.25 && abs(p.z - 0.12) < 0.25 else { continue }
@@ -88,7 +88,7 @@ final class ClothTests: XCTestCase {
                     let c = gpu.bodyPosition(t.ids.2)
                     let n = normalize(cross(bb - a, c - a))    // +z winding
                     let sd = dot(p - a, n)
-                    guard sd < -0.06 && sd > -0.3 else { continue }
+                    guard sd < -1e-4 else { continue }
                     // interior check via barycentric of the planar projection
                     let q = p - n * sd
                     let v0 = bb - a, v1 = c - a, v2 = q - a
@@ -100,8 +100,6 @@ final class ClothTests: XCTestCase {
                     let w = (d00 * d21 - d01 * d20) / den
                     if v > 0.1 && w > 0.1 && (1 - v - w) > 0.1 {
                         violations += 1
-                        print(String(format: "VIOLATION f=%d node=%d depth=%.3f at (%.2f, %.2f, %.2f)",
-                                     f, b, sd, p.x, p.y, p.z))
                     }
                 }
             }

--- a/Tests/PhysicsAVBDTests/GPUSolverTests.swift
+++ b/Tests/PhysicsAVBDTests/GPUSolverTests.swift
@@ -382,8 +382,10 @@ final class GPUSolverTests: XCTestCase {
         }
         let solver = try makeGPU(scene)
 
-        // 4*150 surface vertices + 4*50 triangles + 4*150 unique edges.
-        XCTAssertEqual(solver.maxSoft, 1_400)
+        // Full Planar emission budgets 8 records per surface vertex/edge,
+        // plus four rigid-triangle records per triangle. Raw demand is still
+        // checked exactly and fails terminally rather than clipping silently.
+        XCTAssertEqual(solver.maxSoft, 2_600)
     }
 
     func testShadersCompile() throws {

--- a/Tests/PhysicsAVBDTests/PlanarDATTests.swift
+++ b/Tests/PhysicsAVBDTests/PlanarDATTests.swift
@@ -1,0 +1,1039 @@
+import XCTest
+import simd
+@testable import SimCore
+@testable import PhysicsAVBD
+
+final class PlanarDATTests: XCTestCase {
+    private let identity = Quat(real: 1, imag: .zero)
+
+    private struct PairKey: Hashable {
+        let kind: UInt32
+        let owner: UInt32
+        let other: UInt32
+        let flags: UInt32
+
+        init(kind: UInt32, owner: UInt32, other: UInt32,
+             flags: UInt32 = 3) {
+            self.kind = kind
+            self.owner = owner
+            self.other = other
+            self.flags = flags
+        }
+
+        init(_ raw: SIMD4<UInt32>) {
+            self.init(kind: raw.x, owner: raw.y, other: raw.z,
+                      flags: raw.w)
+        }
+    }
+
+    @discardableResult
+    private func addTriangle(
+        _ scene: inout PhysicsScene,
+        _ a: F3, _ b: F3, _ c: F3,
+        radius: Float = 0.01,
+        mass: Float,
+        velocity: F3 = .zero
+    ) -> (triangle: Int, vertices: [Int]) {
+        let vertices = [a, b, c].map {
+            scene.addParticle(
+                radius: radius, mass: mass, friction: 0,
+                position: $0, velocity: velocity)
+        }
+        let triangle = scene.tris.count
+        scene.addTri(SceneTri(ids: (vertices[0], vertices[1], vertices[2])))
+        return (triangle, vertices)
+    }
+
+    /// A large static target containing a much smaller moving triangle in
+    /// projection. The target vertices stay outside the small triangle's DAT
+    /// query radius, which isolates the moving V-T events analytically.
+    private func twoTriangleScene(
+        sourceHeight: Float,
+        sourceVelocity: F3,
+        iterations: Int = 0
+    ) -> (scene: PhysicsScene, target: Int, source: [Int]) {
+        var scene = PhysicsScene(name: "planar-dat-two-triangle")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = iterations
+        let target = addTriangle(
+            &scene,
+            F3(-1, -1, 0), F3(1, -1, 0), F3(0, 1, 0),
+            mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-0.15, -0.10, sourceHeight),
+            F3(0.15, -0.10, sourceHeight),
+            F3(0, 0.15, sourceHeight),
+            mass: 1, velocity: sourceVelocity)
+        return (scene, target.triangle, source.vertices)
+    }
+
+    private func sharedPositions(_ solver: GPUSolver) -> UnsafeMutablePointer<SIMD4<Float>> {
+        solver.posLin.contents().bindMemory(
+            to: SIMD4<Float>.self, capacity: solver.numBodies)
+    }
+
+    private func planarPairCount(_ solver: GPUSolver) -> Int {
+        Int(solver.planarDATPairCountsBuf.contents().bindMemory(
+            to: UInt32.self, capacity: 3)[0])
+    }
+
+    private func planarPairs(_ solver: GPUSolver) -> [SIMD4<UInt32>] {
+        let count = min(planarPairCount(solver), solver.maxPlanarDATPairs)
+        guard count > 0 else { return [] }
+        let pointer = solver.planarDATPairsBuf.contents().bindMemory(
+            to: SIMD4<UInt32>.self, capacity: solver.maxPlanarDATPairs)
+        return Array(UnsafeBufferPointer(start: pointer, count: count))
+    }
+
+    private func position(
+        _ pointer: UnsafeMutablePointer<SIMD4<Float>>, _ index: UInt32
+    ) -> F3 {
+        let p = pointer[Int(index)]
+        return F3(p.x, p.y, p.z)
+    }
+
+    private func pointTriangleDistanceSquared(
+        _ p: F3, _ a: F3, _ b: F3, _ c: F3
+    ) -> Float {
+        let ab = b - a, ac = c - a, ap = p - a
+        let d1 = dot(ab, ap), d2 = dot(ac, ap)
+        if d1 <= 0 && d2 <= 0 { return length_squared(ap) }
+        let bp = p - b
+        let d3 = dot(ab, bp), d4 = dot(ac, bp)
+        if d3 >= 0 && d4 <= d3 { return length_squared(bp) }
+        let vc = d1 * d4 - d3 * d2
+        if vc <= 0 && d1 >= 0 && d3 <= 0 {
+            let v = d1 / (d1 - d3)
+            return length_squared(p - (a + ab * v))
+        }
+        let cp = p - c
+        let d5 = dot(ab, cp), d6 = dot(ac, cp)
+        if d6 >= 0 && d5 <= d6 { return length_squared(cp) }
+        let vb = d5 * d2 - d1 * d6
+        if vb <= 0 && d2 >= 0 && d6 <= 0 {
+            let w = d2 / (d2 - d6)
+            return length_squared(p - (a + ac * w))
+        }
+        let va = d3 * d6 - d5 * d4
+        if va <= 0 && d4 - d3 >= 0 && d5 - d6 >= 0 {
+            let w = (d4 - d3) / ((d4 - d3) + (d5 - d6))
+            return length_squared(p - (b + (c - b) * w))
+        }
+        let denom = 1 / (va + vb + vc)
+        let q = a + ab * (vb * denom) + ac * (vc * denom)
+        return length_squared(p - q)
+    }
+
+    private func segmentSegmentDistanceSquared(
+        _ p0: F3, _ p1: F3, _ q0: F3, _ q1: F3
+    ) -> Float {
+        let d0 = p1 - p0, d1 = q1 - q0, r = p0 - q0
+        let a = dot(d0, d0), e = dot(d1, d1)
+        let epsilon: Float = 1e-12
+        var s: Float = 0
+        var t: Float = 0
+        if a <= epsilon && e <= epsilon {
+            return length_squared(r)
+        }
+        if a <= epsilon {
+            t = min(max(dot(d1, r) / e, 0), 1)
+        } else {
+            let c = dot(d0, r)
+            if e <= epsilon {
+                s = min(max(-c / a, 0), 1)
+            } else {
+                let b = dot(d0, d1)
+                let f = dot(d1, r)
+                let denominator = a * e - b * b
+                if denominator != 0 {
+                    s = min(max((b * f - c * e) / denominator, 0), 1)
+                }
+                let projectedT = (b * s + f) / e
+                if projectedT < 0 {
+                    t = 0
+                    s = min(max(-c / a, 0), 1)
+                } else if projectedT > 1 {
+                    t = 1
+                    s = min(max((b - c) / a, 0), 1)
+                } else {
+                    t = projectedT
+                }
+            }
+        }
+        return length_squared((p0 + d0 * s) - (q0 + d1 * t))
+    }
+
+    /// Brute-force accepted-pose oracle, independent of the GPU hash grid.
+    /// It mirrors only the public Planar-DAT pair contract: exact rq distance,
+    /// canonical E-E ownership, and one-edge-ring topology filtering.
+    private func acceptedPairOracle(_ solver: GPUSolver) -> Set<PairKey> {
+        let positions = sharedPositions(solver)
+        let triangles = solver.trisBuf.contents().bindMemory(
+            to: SIMD4<UInt32>.self, capacity: max(1, solver.numTris))
+        let edges = solver.edgesBuf.contents().bindMemory(
+            to: SIMD2<UInt32>.self,
+            capacity: max(1, solver.numPlanarDATEdges))
+        let particles = solver.particleIdxBuf.contents().bindMemory(
+            to: UInt32.self, capacity: max(1, solver.numParticles))
+        var oneRing = [Set<UInt32>](repeating: [], count: solver.numBodies)
+        for ti in 0..<solver.numTris {
+            let t = triangles[ti]
+            for (u, v) in [(t.x, t.y), (t.y, t.z), (t.x, t.z)] {
+                oneRing[Int(u)].insert(v)
+                oneRing[Int(v)].insert(u)
+            }
+        }
+
+        let rq2 = solver.params.planarDATQueryRadius
+            * solver.params.planarDATQueryRadius
+        var expected = Set<PairKey>()
+        for pi in 0..<solver.numParticles {
+            let v = particles[pi]
+            let p = position(positions, v)
+            for ti in 0..<solver.numTris {
+                let t = triangles[ti]
+                if t.x == v || t.y == v || t.z == v { continue }
+                if oneRing[Int(v)].contains(t.x)
+                    || oneRing[Int(v)].contains(t.y)
+                    || oneRing[Int(v)].contains(t.z) { continue }
+                let distance2 = pointTriangleDistanceSquared(
+                    p, position(positions, t.x), position(positions, t.y),
+                    position(positions, t.z))
+                if distance2 <= rq2 {
+                    expected.insert(PairKey(
+                        kind: 0, owner: v, other: UInt32(ti)))
+                }
+            }
+        }
+
+        for first in 0..<solver.numPlanarDATEdges {
+            let a = edges[first]
+            for second in (first + 1)..<solver.numPlanarDATEdges {
+                let b = edges[second]
+                if a.x == b.x || a.x == b.y || a.y == b.x || a.y == b.y {
+                    continue
+                }
+                if oneRing[Int(a.x)].contains(b.x)
+                    || oneRing[Int(a.x)].contains(b.y)
+                    || oneRing[Int(a.y)].contains(b.x)
+                    || oneRing[Int(a.y)].contains(b.y) { continue }
+                let distance2 = segmentSegmentDistanceSquared(
+                    position(positions, a.x), position(positions, a.y),
+                    position(positions, b.x), position(positions, b.y))
+                if distance2 <= rq2 {
+                    expected.insert(PairKey(
+                        kind: 1, owner: UInt32(first),
+                        other: UInt32(second)))
+                }
+            }
+        }
+        return expected
+    }
+
+    private func edgeIndex(
+        _ solver: GPUSolver, _ first: Int, _ second: Int
+    ) -> UInt32? {
+        let lo = UInt32(min(first, second)), hi = UInt32(max(first, second))
+        let edges = solver.edgesBuf.contents().bindMemory(
+            to: SIMD2<UInt32>.self,
+            capacity: max(1, solver.numPlanarDATEdges))
+        for index in 0..<solver.numPlanarDATEdges {
+            let edge = edges[index]
+            if edge.x == lo && edge.y == hi { return UInt32(index) }
+        }
+        return nil
+    }
+
+    func testVertexTrianglePredictorMatchesAnalyticDivisionPlane() throws {
+        let startZ: Float = 0.2
+        let velocityZ: Float = -0.4
+        let fixture = twoTriangleScene(
+            sourceHeight: startZ,
+            sourceVelocity: F3(0, 0, velocityZ))
+        let solver = try GPUSolver(scene: fixture.scene)
+
+        // The static target gets the minimum 5% allocation of the initial
+        // gap. The moving vertex reaches that division plane at hit=0.475;
+        // Planar-DAT applies gamma*hit because it is stricter than hit-0.001.
+        let planeZ = startZ * 0.05
+        let hit = (startZ - planeZ) / -velocityZ
+        let t = min(
+            solver.params.planarDATRelaxation * hit,
+            hit - 0.001)
+        let expectedZ = startZ + velocityZ * t
+        let globalCap = 0.5 * solver.params.planarDATRelaxation
+            * solver.params.planarDATQueryRadius
+        XCTAssertLessThan(abs(velocityZ * t), globalCap,
+                          "the analytic plane, not the global rq cap, must bind")
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let positions = sharedPositions(solver)
+        for vertex in fixture.source {
+            XCTAssertEqual(positions[vertex].z, expectedZ, accuracy: 2e-5)
+        }
+        XCTAssertGreaterThanOrEqual(solver.lastPlanarDATVertexTrianglePairs, 3)
+        XCTAssertGreaterThanOrEqual(solver.lastPlanarDATTruncations, 3)
+    }
+
+    func testSameConnectedSolidVertexTrianglePairsAreSafetyOnly() throws {
+        let fixture = twoTriangleScene(
+            sourceHeight: 0.03, sourceVelocity: .zero)
+        let solver = try GPUSolver(scene: fixture.scene)
+
+        // White-box the force-eligibility boundary: the geometric pair and
+        // topology stay unchanged, but both surfaces now represent one
+        // connected volumetric solid rather than two cloth components.
+        let groups = solver.clothGroupBuf.contents().bindMemory(
+            to: UInt32.self, capacity: solver.numBodies)
+        let cloth = solver.clothVertFlag.contents().bindMemory(
+            to: UInt32.self, capacity: solver.numBodies)
+        let target = fixture.scene.tris[fixture.target].ids
+        for vertex in fixture.source + [target.0, target.1, target.2] {
+            groups[vertex] = 7
+            cloth[vertex] = 0
+        }
+
+        try solver.submitStep()
+        try solver.synchronize()
+        let pairs = planarPairs(solver).filter { $0.x == 0 }
+        XCTAssertFalse(
+            pairs.isEmpty,
+            "expected same-solid V-T safety pairs; peak=\(solver.lastPlanarDATPairs) "
+                + "VT=\(solver.lastPlanarDATVertexTrianglePairs)")
+        XCTAssertTrue(pairs.allSatisfy { $0.w == 1 },
+                      "same-solid V-T pairs must truncate without OGC force")
+    }
+
+    func testFullPairStreamKeepsSixVertexTrianglePairsForOneVertex() throws {
+        var scene = PhysicsScene(name: "planar-dat-full-vt-stream")
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+
+        let targetCount = 6
+        for layer in 1...targetCount {
+            let z = Float(layer) * 0.1
+            addTriangle(
+                &scene,
+                F3(-1, -1, z), F3(1, -1, z), F3(0, 1, z),
+                mass: 0)
+        }
+        let source = addTriangle(
+            &scene,
+            F3(-0.15, -0.10, 0),
+            F3(0.15, -0.10, 0),
+            F3(0, 0.15, 0),
+            mass: 1)
+        let owner = source.vertices[2]
+        let solver = try GPUSolver(scene: scene)
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        // data = (kind, owner vertex/edge, triangle/edge, flags), with kind 0
+        // denoting V-T. Count this owner's six authored targets in the full
+        // conservative stream, not merely a global aggregate counter.
+        let ownedTargets = planarPairs(solver).filter {
+            $0.x == 0 && $0.y == UInt32(owner) && $0.z < UInt32(targetCount)
+        }
+        XCTAssertEqual(ownedTargets.count, targetCount)
+        XCTAssertEqual(Set(ownedTargets.map(\.z)).count, targetCount,
+                       "the compact stream must neither cap at four nor duplicate a target")
+        XCTAssertGreaterThan(solver.lastPlanarDATVertexTrianglePairs, 4)
+        XCTAssertEqual(solver.lastPlanarDATTruncations, 0)
+    }
+
+    func testAcceptedPairSetMatchesExactCPUOracle() throws {
+        var scene = PhysicsScene(name: "planar-dat-pair-oracle")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+
+        // Two triangles form one connected square at z=0. A disconnected
+        // layer at z=.06 must produce V-T and E-E candidates, while the
+        // geometrically identical layer at z=.30 is beyond rq.
+        let lowerA = addTriangle(
+            &scene,
+            F3(-0.05, -0.05, 0), F3(0.05, -0.05, 0),
+            F3(-0.05, 0.05, 0), radius: 0.005, mass: 1)
+        let lowerD = scene.addParticle(
+            radius: 0.005, mass: 1, friction: 0,
+            position: F3(0.05, 0.05, 0), velocity: .zero)
+        let lowerBTriangle = scene.tris.count
+        let lowerBVertices = [lowerA.vertices[1], lowerD, lowerA.vertices[2]]
+        scene.addTri(SceneTri(ids: (
+            lowerBVertices[0], lowerBVertices[1], lowerBVertices[2])))
+        let lowerB = (triangle: lowerBTriangle, vertices: lowerBVertices)
+        let nearLayer = addTriangle(
+            &scene,
+            F3(-0.05, -0.05, 0.06), F3(0.05, -0.05, 0.06),
+            F3(-0.05, 0.05, 0.06), radius: 0.005, mass: 1)
+        let farLayer = addTriangle(
+            &scene,
+            F3(-0.05, -0.05, 0.30), F3(0.05, -0.05, 0.30),
+            F3(-0.05, 0.05, 0.30), radius: 0.005, mass: 1)
+        let solver = try GPUSolver(scene: scene)
+        solver.params.planarDATQueryRadius = 0.13
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let raw = planarPairs(solver)
+        let actualList = raw.map(PairKey.init)
+        let actual = Set(actualList)
+        let expected = acceptedPairOracle(solver)
+        XCTAssertEqual(actualList.count, actual.count,
+                       "the final compact pair stream must contain no duplicates")
+        XCTAssertEqual(actual, expected,
+                       "the GPU grid must be exactly equivalent to the brute-force rq query")
+        XCTAssertTrue(expected.contains { $0.kind == 0 },
+                      "the fixture must exercise retained V-T pairs")
+        XCTAssertTrue(expected.contains { $0.kind == 1 },
+                      "the fixture must exercise retained E-E pairs")
+
+        // lowerA.v0 is within rq of lowerB, but lowerB contains direct
+        // one-ring neighbors from the connected square, so V-T is excluded.
+        let excludedVT = PairKey(
+            kind: 0, owner: UInt32(lowerA.vertices[0]),
+            other: UInt32(lowerB.triangle))
+        XCTAssertLessThan(
+            pointTriangleDistanceSquared(
+                scene.bodies[lowerA.vertices[0]].position,
+                scene.bodies[lowerB.vertices[0]].position,
+                scene.bodies[lowerB.vertices[1]].position,
+                scene.bodies[lowerB.vertices[2]].position),
+            solver.params.planarDATQueryRadius
+                * solver.params.planarDATQueryRadius)
+        XCTAssertFalse(actual.contains(excludedVT))
+
+        // The opposite square edges are also geometrically within rq, but
+        // their endpoints are connected by the one-ring mesh topology.
+        let edgeAB = try XCTUnwrap(edgeIndex(
+            solver, lowerA.vertices[0], lowerA.vertices[1]))
+        let edgeDC = try XCTUnwrap(edgeIndex(
+            solver, lowerB.vertices[1], lowerB.vertices[2]))
+        let excludedEE = PairKey(
+            kind: 1, owner: min(edgeAB, edgeDC),
+            other: max(edgeAB, edgeDC))
+        XCTAssertFalse(actual.contains(excludedEE))
+
+        // A representative disconnected pair is accepted at .06, whereas
+        // its otherwise identical .30 counterpart fails only the exact rq
+        // distance predicate (not topology).
+        XCTAssertTrue(actual.contains(PairKey(
+            kind: 0, owner: UInt32(nearLayer.vertices[0]),
+            other: UInt32(lowerA.triangle))))
+        XCTAssertFalse(actual.contains(PairKey(
+            kind: 0, owner: UInt32(farLayer.vertices[0]),
+            other: UInt32(lowerA.triangle))))
+    }
+
+    func testAcceptedPoseQueryDropsPairThatMovedOutsideRadius() throws {
+        var fixture = twoTriangleScene(
+            sourceHeight: 0.5, sourceVelocity: .zero)
+        fixture.scene.settings.iterations = 0
+        let solver = try GPUSolver(scene: fixture.scene)
+        let rq = solver.params.planarDATQueryRadius
+        let startZ = 0.8 * rq
+        let velocity = F3(0, 0, 2 * rq)
+        solver.setBodyStates(fixture.source.map {
+            .init(body: $0,
+                  position: F3(fixture.scene.bodies[$0].position.x,
+                               fixture.scene.bodies[$0].position.y,
+                               startZ),
+                  rotation: identity,
+                  linearVelocity: velocity)
+        })
+
+        var passSites: [GPUSolver.PlanarDATPassSite] = []
+        solver.planarDATPassObserverForTesting = { passSites.append($0) }
+        try solver.submitStep()
+        try solver.synchronize()
+
+        // Moving away is safe, so only the unconditional rq cap applies:
+        // 0.8rq + 0.425rq lies beyond rq. Peak telemetry proves the start
+        // query saw the pair, while the final buffer proves the independent
+        // accepted-pose query dropped it before the color solve.
+        XCTAssertEqual(passSites, [.predictor])
+        XCTAssertGreaterThan(solver.lastPlanarDATPairs, 0,
+                             "the start query must see the nearby pair")
+        XCTAssertEqual(planarPairCount(solver), 0,
+                       "the accepted-pose query must drop a pair outside rq")
+
+        let positions = sharedPositions(solver)
+        let anchors = solver.ogcPrevBuf.contents().bindMemory(
+            to: SIMD4<Float>.self, capacity: solver.numBodies)
+        for vertex in fixture.source {
+            XCTAssertGreaterThan(positions[vertex].z, rq)
+            XCTAssertEqual(anchors[vertex].x, positions[vertex].x, accuracy: 1e-6)
+            XCTAssertEqual(anchors[vertex].y, positions[vertex].y, accuracy: 1e-6)
+            XCTAssertEqual(anchors[vertex].z, positions[vertex].z, accuracy: 1e-6)
+        }
+    }
+
+    func testAcceptedPoseQueryFindsEnteringContactWithCurrentMasses() throws {
+        // Keep the authored edges small enough that rq is derived from the
+        // physical contact reach rather than a large triangle's edge length.
+        // This makes the accepted pose enter both rq and the OGC force band.
+        var scene = PhysicsScene(name: "planar-dat-entering-contact")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        addTriangle(
+            &scene,
+            F3(-0.04, -0.04, 0), F3(0.04, -0.04, 0), F3(0, 0.04, 0),
+            mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-0.01, -0.007, 0.5), F3(0.01, -0.007, 0.5),
+            F3(0, 0.01, 0.5), mass: 1)
+        let solver = try GPUSolver(scene: scene)
+        let rq = solver.params.planarDATQueryRadius
+        let startZ = 1.01 * rq
+        let velocity = F3(0, 0, -2 * rq)
+        solver.setBodyStates(source.vertices.map {
+            .init(
+                body: $0,
+                position: F3(
+                    scene.bodies[$0].position.x,
+                    scene.bodies[$0].position.y,
+                    startZ),
+                rotation: identity,
+                linearVelocity: velocity)
+        })
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        XCTAssertGreaterThan(startZ, rq)
+        XCTAssertGreaterThanOrEqual(solver.lastNumSoft, 3,
+                                    "a pair entering rq during prediction must emit at the accepted pose")
+        let positions = sharedPositions(solver)
+        for vertex in source.vertices {
+            XCTAssertTrue(positions[vertex].z.isFinite)
+            XCTAssertLessThan(positions[vertex].z, rq)
+            XCTAssertEqual(
+                positions[vertex].z,
+                startZ - 0.5 * solver.params.planarDATRelaxation * rq,
+                accuracy: 2e-5)
+        }
+    }
+
+    func testAcceptedPoseVTContactStoresStartLinearizedC0() throws {
+        var scene = PhysicsScene(name: "planar-dat-accepted-vt-c0")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        scene.settings.alpha = 0.99
+        let target = addTriangle(
+            &scene,
+            F3(-0.04, -0.04, 0), F3(0.04, -0.04, 0),
+            F3(0, 0.04, 0), mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-0.01, -0.007, 0.5), F3(0.01, -0.007, 0.5),
+            F3(0, 0.01, 0.5), mass: 1)
+        let solver = try GPUSolver(scene: scene)
+        let rq = solver.params.planarDATQueryRadius
+        let startZ = 1.01 * rq
+        let velocity = F3(0, 0, -2 * rq)
+        solver.setBodyStates(source.vertices.map {
+            .init(
+                body: $0,
+                position: F3(
+                    scene.bodies[$0].position.x,
+                    scene.bodies[$0].position.y,
+                    startZ),
+                rotation: identity,
+                linearVelocity: velocity)
+        })
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let contacts = solver.prevSoftContacts.contents().bindMemory(
+            to: SoftContactGPU.self, capacity: max(1, solver.maxSoft))
+        let contactCount = min(solver.lastNumSoft, solver.maxSoft)
+        let sourceVertex = UInt32(source.vertices[2])
+        let targetIDs = target.vertices.map(UInt32.init)
+        let contact = try XCTUnwrap((0..<contactCount).lazy.map {
+            contacts[$0]
+        }.first {
+            let kind = ($0.anchorA.w.bitPattern >> 2) & 0x7
+            return kind == 1 && $0.ids.x == sourceVertex
+                && $0.ids.y == targetIDs[0]
+                && $0.ids.z == targetIDs[1]
+                && $0.ids.w == targetIDs[2]
+        }, "the accepted-pose query must emit the selected V-T contact")
+
+        let accepted = sharedPositions(solver)
+        let starts = solver.initLin.contents().bindMemory(
+            to: SIMD4<Float>.self, capacity: solver.numBodies)
+        let shape = solver.shape.contents().bindMemory(
+            to: SIMD4<Float>.self, capacity: solver.numBodies)
+        let n = F3(contact.normal.x, contact.normal.y, contact.normal.z)
+        var startRelative = F3.zero
+        var acceptedRelative = F3.zero
+        for slot in 0..<4 {
+            let id = contact.ids[slot]
+            let weight = contact.weights[slot]
+            startRelative += weight * position(starts, id)
+            acceptedRelative += weight * position(accepted, id)
+        }
+        let hSum = abs(shape[Int(contact.ids.x)].w) + max(
+            abs(shape[Int(contact.ids.y)].w),
+            max(abs(shape[Int(contact.ids.z)].w),
+                abs(shape[Int(contact.ids.w)].w)))
+        let expectedC0 = dot(n, startRelative) - hSum
+            + solver.params.elemMargin
+        let acceptedC = dot(n, acceptedRelative) - hSum
+            + solver.params.elemMargin
+        let predictorNormalDisplacement = dot(
+            n, acceptedRelative - startRelative)
+
+        XCTAssertEqual(solver.params.alpha, 0.99, accuracy: 1e-7)
+        XCTAssertGreaterThan(abs(predictorNormalDisplacement), 1e-4,
+                             "the fixture must exercise normal predictor motion")
+        XCTAssertEqual(contact.C0.x,
+                       acceptedC - predictorNormalDisplacement,
+                       accuracy: 2e-5)
+        XCTAssertEqual(contact.C0.x, expectedC0, accuracy: 2e-5,
+                       "C0 must be back-linearized to the step-start pose")
+        XCTAssertGreaterThan(abs(expectedC0), 1e-3)
+        XCTAssertGreaterThan(
+            abs(contact.C0.x - expectedC0 / (1 - solver.params.alpha)),
+            10 * abs(expectedC0),
+            "accepted-pose back-linearization must not divide C0 by 1-alpha")
+    }
+
+    func testNonfinitePredictionFreezesAtFiniteAnchorAndThrows() throws {
+        let startZ: Float = 0.2
+        let fixture = twoTriangleScene(
+            sourceHeight: startZ, sourceVelocity: .zero)
+        let solver = try GPUSolver(scene: fixture.scene)
+        let velocities = solver.velLin.contents().bindMemory(
+            to: SIMD4<Float>.self, capacity: solver.numBodies)
+        for vertex in fixture.source {
+            velocities[vertex].z = .infinity
+        }
+
+        try solver.submitStep()
+        XCTAssertThrowsError(try solver.synchronize()) { error in
+            guard case let GPUSolver.RuntimeFailure.commandExecution(
+                _, frame, _, domain, code, message) = error,
+                  domain == GPUSolver.RuntimeFailure.planarDATFailureDomain,
+                  code == GPUSolver.RuntimeFailure.planarDATInvalidAnchorCode else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(frame, 1)
+            XCTAssertTrue(message.contains("Planar-DAT pairs"))
+        }
+
+        let positions = sharedPositions(solver)
+        for vertex in fixture.source {
+            XCTAssertTrue(positions[vertex].z.isFinite)
+            XCTAssertEqual(positions[vertex].z, startZ, accuracy: 1e-6)
+        }
+    }
+
+    func testPlanarDATRunsAfterEveryVBDColor() throws {
+        let iterations = 2
+        let fixture = twoTriangleScene(
+            sourceHeight: 0.2, sourceVelocity: .zero,
+            iterations: iterations)
+        let solver = try GPUSolver(scene: fixture.scene)
+        var observed: [GPUSolver.PlanarDATPassSite] = []
+        solver.planarDATPassObserverForTesting = { observed.append($0) }
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        var expected: [GPUSolver.PlanarDATPassSite] = [.predictor]
+        for iteration in 0..<iterations {
+            for color in 0..<solver.staticUsedColors {
+                expected.append(.color(iteration: iteration, color: color))
+            }
+        }
+        XCTAssertEqual(observed, expected)
+    }
+
+    func testPerColorDATRestoresAllPrimalBindings() throws {
+        var scene = Demos.clothfold(res: 36)
+        scene.settings.iterations = 10
+        let solver = try GPUSolver(scene: scene)
+        XCTAssertGreaterThanOrEqual(solver.staticUsedColors, 2)
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let (_, stretch) = solver.debugClothMetrics()
+        XCTAssertLessThan(
+            stretch, 0.01,
+            "a DAT dispatch must not leave its counter buffer bound as springs for the next color")
+    }
+
+    func testBilateralVertexTrianglePlaneAllocatesRelativeMotion() throws {
+        var scene = PhysicsScene(name: "planar-dat-bilateral-vt")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        let target = addTriangle(
+            &scene,
+            F3(-1, -1, 0), F3(1, -1, 0), F3(0, 1, 0),
+            mass: 1, velocity: F3(0, 0, 0.1))
+        let source = addTriangle(
+            &scene,
+            F3(-0.15, -0.10, 0.2),
+            F3(0.15, -0.10, 0.2),
+            F3(0, 0.15, 0.2),
+            mass: 1, velocity: F3(0, 0, -0.3))
+        let solver = try GPUSolver(scene: scene)
+
+        // Relative approach is 0.4. The target receives 25% of the gap,
+        // so both sides hit their shared plane at 0.5 and accept gamma*hit.
+        let t: Float = 0.5 * solver.params.planarDATRelaxation
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let positions = sharedPositions(solver)
+        for v in source.vertices {
+            XCTAssertEqual(positions[v].z, 0.2 - 0.3 * t, accuracy: 2e-5)
+        }
+        for v in target.vertices {
+            XCTAssertEqual(positions[v].z, 0.1 * t, accuracy: 2e-5)
+        }
+    }
+
+    func testExactVertexTrianglePlaneHitIsStrictlyTruncated() throws {
+        let fixture = twoTriangleScene(
+            sourceHeight: 0.2,
+            sourceVelocity: F3(0, 0, -0.19))
+        let solver = try GPUSolver(scene: fixture.scene)
+
+        // A static target receives the minimum 5% room, so -0.19 lands
+        // exactly on its z=.01 division plane at t=1. The half-space is
+        // strict: the accepted endpoint must be gamma-scaled, not left on it.
+        let expectedZ: Float = 0.2 - 0.19 * solver.params.planarDATRelaxation
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let positions = sharedPositions(solver)
+        for v in fixture.source {
+            XCTAssertEqual(positions[v].z, expectedZ, accuracy: 2e-5)
+            XCTAssertGreaterThan(positions[v].z, 0.01)
+        }
+    }
+
+    func testStrictestSimultaneousDivisionPlaneWins() throws {
+        var scene = PhysicsScene(name: "planar-dat-strictest-plane")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        addTriangle(
+            &scene,
+            F3(-1, -1, 0), F3(1, -1, 0), F3(0, 1, 0), mass: 0)
+        addTriangle(
+            &scene,
+            F3(-1, -1, 0.1), F3(1, -1, 0.1), F3(0, 1, 0.1), mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-0.15, -0.10, 0.2),
+            F3(0.15, -0.10, 0.2),
+            F3(0, 0.15, 0.2),
+            mass: 1, velocity: F3(0, 0, -0.4))
+        let solver = try GPUSolver(scene: scene)
+
+        let hit: Float = (0.2 - 0.105) / 0.4
+        let t = min(solver.params.planarDATRelaxation * hit, hit - 0.001)
+        let expectedZ: Float = 0.2 - 0.4 * t
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let positions = sharedPositions(solver)
+        for v in source.vertices {
+            XCTAssertEqual(positions[v].z, expectedZ, accuracy: 2e-5)
+            XCTAssertGreaterThan(positions[v].z, 0.105)
+        }
+    }
+
+    func testTangentialMotionPreservesMoreProgressThanIsotropicDAT() throws {
+        func makeSolver(_ mode: GPUSolver.SurfaceTruncationMode) throws
+            -> (GPUSolver, [Int], [F3]) {
+            let fixture = twoTriangleScene(
+                sourceHeight: 0.05,
+                sourceVelocity: F3(0.1, 0, 0))
+            let starts = fixture.source.map { fixture.scene.bodies[$0].position }
+            let solver = try GPUSolver(scene: fixture.scene)
+            solver.surfaceTruncationMode = mode
+            return (solver, fixture.source, starts)
+        }
+
+        let (planar, planarIDs, starts) = try makeSolver(.planarDAT)
+        let (isotropic, isotropicIDs, _) = try makeSolver(.isotropicDAT)
+        try planar.submitStep()
+        try planar.synchronize()
+        try isotropic.submitStep()
+        try isotropic.synchronize()
+
+        let planarPositions = sharedPositions(planar)
+        let isotropicPositions = sharedPositions(isotropic)
+        for i in planarIDs.indices {
+            let dxPlanar = planarPositions[planarIDs[i]].x - starts[i].x
+            let dxIsotropic = isotropicPositions[isotropicIDs[i]].x - starts[i].x
+            XCTAssertGreaterThan(dxPlanar, 0.095)
+            XCTAssertLessThan(dxIsotropic, 0.05)
+            XCTAssertGreaterThan(dxPlanar, 2 * dxIsotropic)
+            XCTAssertEqual(planarPositions[planarIDs[i]].z, 0.05, accuracy: 1e-5)
+            XCTAssertEqual(isotropicPositions[isotropicIDs[i]].z, 0.05, accuracy: 1e-5)
+        }
+    }
+
+    func testVertexTriangleTruncationIsTranslationInvariant() throws {
+        let offset = F3(10_000, -10_000, 10_000)
+        var scene = PhysicsScene(name: "planar-dat-translated-vt")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        addTriangle(
+            &scene,
+            offset + F3(-1, -1, 0),
+            offset + F3(1, -1, 0),
+            offset + F3(0, 1, 0), mass: 0)
+        let source = addTriangle(
+            &scene,
+            offset + F3(-0.15, -0.10, 0.2),
+            offset + F3(0.15, -0.10, 0.2),
+            offset + F3(0, 0.15, 0.2),
+            mass: 1, velocity: F3(0, 0, -0.4))
+        let solver = try GPUSolver(scene: scene)
+        let hit: Float = 0.95 * 0.2 / 0.4
+        let t = min(solver.params.planarDATRelaxation * hit, hit - 0.001)
+        let expectedRelativeZ: Float = 0.2 - 0.4 * t
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        let positions = sharedPositions(solver)
+        for v in source.vertices {
+            XCTAssertEqual(positions[v].z - offset.z,
+                           expectedRelativeZ, accuracy: 0.002)
+        }
+    }
+
+    func testEdgeEdgePredictorMatchesAnalyticDivisionPlane() throws {
+        var scene = PhysicsScene(name: "planar-dat-ee")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        addTriangle(
+            &scene,
+            F3(0, -1, 0), F3(0, 1, 0), F3(0.02, -1, 0), mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-1, 0, 0.2), F3(1, 0, 0.2), F3(-1, 0.02, 0.2),
+            mass: 1, velocity: F3(0, 0, -0.4))
+        let solver = try GPUSolver(scene: scene)
+        solver.params.planarDATQueryRadius = 0.5
+
+        let hit: Float = 0.95 * 0.2 / 0.4
+        let t = min(solver.params.planarDATRelaxation * hit, hit - 0.001)
+        let expectedZ: Float = 0.2 - 0.4 * t
+        try solver.submitStep()
+        try solver.synchronize()
+
+        XCTAssertEqual(solver.lastPlanarDATVertexTrianglePairs, 0)
+        XCTAssertGreaterThan(solver.lastPlanarDATEdgeEdgePairs, 0)
+        let positions = sharedPositions(solver)
+        XCTAssertEqual(positions[source.vertices[0]].z, expectedZ, accuracy: 2e-5)
+        XCTAssertEqual(positions[source.vertices[1]].z, expectedZ, accuracy: 2e-5)
+        XCTAssertGreaterThan(positions[source.vertices[0]].z, 0.01)
+        XCTAssertGreaterThan(positions[source.vertices[1]].z, 0.01)
+    }
+
+    func testExactEdgeEdgePlaneHitIsStrictlyTruncated() throws {
+        var scene = PhysicsScene(name: "planar-dat-exact-ee-hit")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        addTriangle(
+            &scene,
+            F3(0, -1, 0), F3(0, 1, 0), F3(0.02, -1, 0), mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-1, 0, 0.2), F3(1, 0, 0.2), F3(-1, 0.02, 0.2),
+            mass: 1, velocity: F3(0, 0, -0.19))
+        let solver = try GPUSolver(scene: scene)
+        solver.params.planarDATQueryRadius = 0.5
+
+        // The static edge receives the minimum 5% room, so the trial endpoint
+        // lands exactly on z=.01. Planar-DAT uses strict half-spaces: equality
+        // is truncated by gamma instead of being accepted as non-crossing.
+        let expectedZ: Float = 0.2 - 0.19 * solver.params.planarDATRelaxation
+        try solver.submitStep()
+        try solver.synchronize()
+
+        XCTAssertEqual(solver.lastPlanarDATVertexTrianglePairs, 0)
+        XCTAssertGreaterThan(solver.lastPlanarDATEdgeEdgePairs, 0)
+        let positions = sharedPositions(solver)
+        XCTAssertEqual(positions[source.vertices[0]].z, expectedZ, accuracy: 2e-5)
+        XCTAssertEqual(positions[source.vertices[1]].z, expectedZ, accuracy: 2e-5)
+        XCTAssertGreaterThan(positions[source.vertices[0]].z, 0.01)
+        XCTAssertGreaterThan(positions[source.vertices[1]].z, 0.01)
+    }
+
+    func testIntersectingEdgeAnchorFailsClosed() throws {
+        var scene = PhysicsScene(name: "planar-dat-invalid-ee-anchor")
+        scene.settings.dt = 1
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        addTriangle(
+            &scene,
+            F3(0, -1, 0), F3(0, 1, 0), F3(0.02, -1, 0), mass: 0)
+        let source = addTriangle(
+            &scene,
+            F3(-1, 0, 0), F3(1, 0, 0), F3(-1, 0.02, 0),
+            mass: 1)
+        let solver = try GPUSolver(scene: scene)
+        solver.params.planarDATQueryRadius = 0.3
+
+        try solver.submitStep()
+        XCTAssertThrowsError(try solver.synchronize()) { error in
+            guard case let GPUSolver.RuntimeFailure.commandExecution(
+                _, frame, _, domain, code, message) = error,
+                  domain == GPUSolver.RuntimeFailure.planarDATFailureDomain,
+                  code == GPUSolver.RuntimeFailure.planarDATInvalidAnchorCode else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(frame, 1)
+            XCTAssertTrue(message.contains("Planar-DAT pairs"))
+        }
+        let positions = sharedPositions(solver)
+        for v in source.vertices {
+            XCTAssertEqual(positions[v].z, 0, accuracy: 1e-6)
+        }
+    }
+
+    func testElementSpanOverflowFreezesAndThrows() throws {
+        let fixture = twoTriangleScene(sourceHeight: 0.2, sourceVelocity: .zero)
+        let solver = try GPUSolver(scene: fixture.scene)
+        let target = fixture.scene.tris[fixture.target].ids.0
+        solver.setBodyStates([
+            .init(body: target, position: F3(-100, -1, 0),
+                  rotation: identity, linearVelocity: .zero)
+        ])
+
+        try solver.submitStep()
+        XCTAssertThrowsError(try solver.synchronize()) { error in
+            guard case let GPUSolver.RuntimeFailure.commandExecution(
+                _, frame, _, domain, code, message) = error,
+                  domain == GPUSolver.RuntimeFailure.planarDATFailureDomain,
+                  code == GPUSolver.RuntimeFailure.planarDATElementGridSpanCode else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(frame, 1)
+            XCTAssertTrue(message.contains("element AABBs"))
+        }
+        let positions = sharedPositions(solver)
+        XCTAssertEqual(positions[target].x, -100, accuracy: 1e-6)
+        for v in fixture.source {
+            XCTAssertEqual(positions[v].z, 0.2, accuracy: 1e-6)
+        }
+    }
+
+    func testRigidOnlySceneBypassesPlanarDAT() throws {
+        var scene = PhysicsScene(name: "planar-dat-rigid-no-op")
+        scene.settings.dt = 0.25
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        let body = scene.addBody(
+            size: F3(repeating: 0.2), density: 1, friction: 0,
+            position: .zero, velocity: F3(2, 0, 0), shape: .sphere)
+        let solver = try GPUSolver(scene: scene)
+        var passes: [GPUSolver.PlanarDATPassSite] = []
+        solver.planarDATPassObserverForTesting = { passes.append($0) }
+
+        try solver.submitStep()
+        try solver.synchronize()
+
+        XCTAssertTrue(passes.isEmpty)
+        XCTAssertEqual(solver.lastPlanarDATPairs, 0)
+        XCTAssertEqual(solver.lastPlanarDATTruncations, 0)
+        let position = sharedPositions(solver)[body]
+        XCTAssertEqual(position.x, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(position.y, 0, accuracy: 1e-6)
+        XCTAssertEqual(position.z, 0, accuracy: 1e-6)
+    }
+
+    func testPairOverflowFreezesParticlesBeforeTypedFailure() throws {
+        let startZ: Float = 0.2
+        let fixture = twoTriangleScene(
+            sourceHeight: startZ,
+            sourceVelocity: F3(0, 0, -0.4),
+            iterations: 2)
+        let solver = try GPUSolver(scene: fixture.scene)
+        solver.planarDATPairCapacityForTesting = 0
+
+        try solver.submitStep()
+        XCTAssertThrowsError(try solver.synchronize()) { error in
+            guard case let GPUSolver.RuntimeFailure.commandExecution(
+                _, frame, _, domain, code, _) = error,
+                  domain == GPUSolver.RuntimeFailure.planarDATFailureDomain,
+                  code == GPUSolver.RuntimeFailure.planarDATPairCapacityCode else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(frame, 1)
+        }
+
+        // synchronize() has completed the command before publishing the
+        // terminal error, so shared memory exposes the fail-closed pose.
+        let positions = sharedPositions(solver)
+        for vertex in fixture.source {
+            XCTAssertEqual(positions[vertex].z, startZ, accuracy: 1e-6)
+        }
+        XCTAssertEqual(solver.runtimeFailure,
+                       .planarDATPairCapacity(
+                        frame: 1, required: solver.lastPlanarDATPairs,
+                        capacity: 0))
+    }
+
+    func testSoftContactOverflowRestoresStepStartPoseBeforeTypedFailure() throws {
+        let startZ: Float = 0.05
+        let velocity = F3(0.1, 0, 0)
+        let fixture = twoTriangleScene(
+            sourceHeight: startZ,
+            sourceVelocity: velocity,
+            iterations: 2)
+        let starts = fixture.source.map { fixture.scene.bodies[$0].position }
+        let solver = try GPUSolver(scene: fixture.scene)
+        solver.planarDATSoftCapacityForTesting = 0
+
+        try solver.submitStep()
+        XCTAssertThrowsError(try solver.synchronize()) { error in
+            guard case let GPUSolver.RuntimeFailure.softContactCapacity(
+                frame, required, capacity) = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(frame, 1)
+            XCTAssertGreaterThan(required, 0)
+            XCTAssertEqual(capacity, 0)
+        }
+
+        // Contact overflow is discovered after prediction and before the
+        // color solve. The failed frame must publish neither that prediction
+        // nor a partially solved pose from the clipped contact stream.
+        let positions = sharedPositions(solver)
+        for (index, vertex) in fixture.source.enumerated() {
+            XCTAssertEqual(positions[vertex].x, starts[index].x, accuracy: 1e-6)
+            XCTAssertEqual(positions[vertex].y, starts[index].y, accuracy: 1e-6)
+            XCTAssertEqual(positions[vertex].z, starts[index].z, accuracy: 1e-6)
+        }
+        XCTAssertEqual(
+            solver.runtimeFailure,
+            .softContactCapacity(
+                frame: 1, required: solver.lastSoftCandidates, capacity: 0))
+    }
+
+}


### PR DESCRIPTION
## Summary

- implement Newton-aligned Planar-DAT displacement truncation for deformable-surface vertex–triangle and edge–edge motion
- build exact compact pair streams, re-query the accepted predictor pose, and apply directional truncation after prediction and every VBD color
- keep OGC as the contact-force model, retain isotropic DAT as an explicit A/B mode, and keep same-solid/tet-boundary safety pairs from creating nonphysical OGC forces
- fail closed on pair/contact capacity, grid-span, invalid-anchor, and non-finite failures
- add CLI selection/telemetry, a scoped paper reference, and 22 focused analytic/integration/oracle tests

Planar-DAT is now the deformable-surface default. This intentionally does not claim rigid curved-trajectory DAT, animated-DoF truncation, or explicit tet-inversion planes.

## Why

The previous isotropic displacement bound discards safe tangential motion. Planar-DAT allocates motion against pair-specific separation planes, retaining substantially more useful progress while preserving non-crossing constraints. The implementation follows the paper/Newton invariants and corrects the paper v1 pseudocode inconsistencies through analytic tests.

## Validation

- `make verify-release`
  - complete SwiftPM suite: 540 tests, 15 expected SwiftPM MLX-resource skips, 0 failures
  - packaged MLX suite: 142 tests, 0 skips, 0 failures
  - signed ML-enabled app package and exact policy inventory
  - architecture, Arachne assets, policy evidence, Panda, H1, and Isaac provenance gates
- `swift package diagnose-api-breaking-changes origin/main --products SimCore PhysicsAVBD Robotics RL MLXRL`: no breaks in all five products
- tooling tests: 40/40
- independent adversarial code reviews: no P0/P1 findings

Focused coverage includes exact CPU-oracle pair-set equality/no duplicates, analytic bilateral V–T and E–E planes, strict exact hits, translation invariance, >4-pair density, accepted-pose entering/leaving pairs, every-color scheduling, same-solid/tet force eligibility, and fail-closed overflow/non-finite restoration.

## Performance evidence

Independent uncontended Release A/B runs used 30 warmup + 240 measured frames at 10 iterations:

| Scene | Planar / isotropic GPU time | Planar / isotropic wall time |
|---|---:|---:|
| twist40 | 0.511× | 0.564× |
| clothfold48 | 0.489× | 0.524× |
| multidrape26 | 0.800× | 0.825× |
| ribbons22 | 0.436× | 0.526× |

The repository does not embed these machine-specific numbers as product claims; they are PR validation evidence.