### PR TITLE
Sliding drops the friction anchor: kinetic friction must dissipate, not store

### DIFF
--- a/Sources/PhysicsAVBD/CPU/CPUManifold.swift
+++ b/Sources/PhysicsAVBD/CPU/CPUManifold.swift
@@ -400,6 +400,9 @@ public final class CPUManifold: CPUForce {
                 contacts[i].penalty[2] = min(contacts[i].penalty[2] + solver.betaLin * abs(C[2]),
                                              AVBDConstants.penaltyMaxTangent)
                 contacts[i].stick = length(SIMD2<Float>(C[1], C[2])) < AVBDConstants.stickThresh
+            } else {
+                // Sliding drops the anchor (see the GPU dual update).
+                contacts[i].stick = false
             }
         }
         if !contacts.isEmpty, torsionalFriction > 0 {

--- a/Sources/PhysicsAVBD/Shaders/40_solver.metal
+++ b/Sources/PhysicsAVBD/Shaders/40_solver.metal
@@ -2261,6 +2261,11 @@ static inline void dual_manifold_one(
             pen.y = min(pen.y + P.betaLin * fabs(C.y), PENALTY_MAX_T);
             pen.z = min(pen.z + P.betaLin * fabs(C.z), PENALTY_MAX_T);
             m.contacts[i].rB.w = length(C.yz) < STICK_THRESH ? 1.0f : 0.0f;
+        } else {
+            // Sliding drops the anchor: without this, a once-stuck contact
+            // keeps its anchors through the whole slide and the stored
+            // tangential constraint hauls the body back when the push ends.
+            m.contacts[i].rB.w = 0.0f;
         }
         m.contacts[i].penalty = float4(pen, 0);
     }

--- a/Tests/AVBDTests/RLFrameworkTests.swift
+++ b/Tests/AVBDTests/RLFrameworkTests.swift
@@ -161,9 +161,11 @@ final class RLFrameworkTests: XCTestCase {
             "every knee must physically reach the under-body compact pose")
         XCTAssertGreaterThan(minimumUpright, 0.85)
         XCTAssertGreaterThan(final.root.position.z, 0.06)
-        XCTAssertLessThan(planarDisplacement, 0.04)
+        // Bounds loosened with the sliding-friction anchor fix: the old
+        // values encoded feet that were tethered to their touchdown points.
+        XCTAssertLessThan(planarDisplacement, 0.07)
         XCTAssertLessThan(
-            final.jointAngles.map(abs).max() ?? .infinity, 0.12,
+            final.jointAngles.map(abs).max() ?? .infinity, 0.17,
             "final joints: \(final.jointAngles); root: \(final.root.position)")
 
         try task.resumeAfterCommissioning(into: &observation)

--- a/Tests/PhysicsAVBDTests/SlidingFrictionAnchorTests.swift
+++ b/Tests/PhysicsAVBDTests/SlidingFrictionAnchorTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+import simd
+@testable import SimCore
+@testable import PhysicsAVBD
+
+/// Kinetic friction must dissipate, not store: with the stick flag only
+/// refreshed in-cone, a once-stuck contact kept stale anchors through a
+/// slide and crept the object back to its touchdown point after release.
+final class SlidingFrictionAnchorTests: XCTestCase {
+
+    /// Push a resting cube with a compliant probe, retract, wait: the cube
+    /// must stay put. The probe must be compliant and force-capped - a
+    /// pose-teleported pusher does not reproduce the bug.
+    func testPushedCubeStaysWhereFrictionStoppedIt() throws {
+        var scene = PhysicsScene(name: "slide-anchor")
+        scene.settings.dt = 1.0 / 240
+        scene.settings.iterations = 20
+        scene.settings.betaLin = 20000
+        scene.settings.betaAng = 500
+        scene.settings.lambdaMax = 1200
+        scene.settings.collisionMargin = 0.003
+        scene.settings.gravity = -9.81
+        _ = scene.addBody(size: F3(2, 2, 0.3), density: 0, friction: 1.0,
+                          position: F3(0, 0, -0.15))
+
+        let cubeSize = F3(0.11, 0.032, 0.030)
+        let cube = scene.addBody(size: cubeSize, density: 420,
+                                 friction: 0.30, dynamicFriction: 0.25,
+                                 position: F3(0, 0, cubeSize.z / 2 + 0.002),
+                                 rotation: Quat(real: 1, imag: .zero),
+                                 velocity: .zero, shape: .box)
+
+        // gravity-free probe on a soft world tether, ~12 N force cap
+        let strike = F3(0, -0.12, 0.017)
+        let probe = scene.addBody(size: F3(repeating: 0.028), density: 3000,
+                                  friction: 0.2, position: strike,
+                                  rotation: Quat(real: 1, imag: .zero),
+                                  velocity: .zero, shape: .box,
+                                  mass: nil, diagonalInertia: nil,
+                                  gravityScale: 0)
+        let driver = scene.joints.count
+        scene.addJoint(SceneJoint(bodyA: -1, bodyB: probe,
+                                  rA: strike, rB: .zero,
+                                  stiffnessLin: 3000, stiffnessAng: 0))
+
+        let solver = try GPUSolver(scene: scene)
+        for _ in 0..<120 { try solver.submitStep() }
+        try solver.synchronize()
+
+        let dir = F3(0, 1, 0)
+        let maxOffset: Float = 12.0 / 3000
+        var pushedY: Float = 0
+        for tick in 0...700 {
+            let t = min(Float(tick) / 420, 1)
+            var goal = strike + dir * (0.16 * t)
+            if tick > 460 {
+                goal = strike - dir * 0.15      // retract clear of everything
+            }
+            let probePos = solver.bodyPosition(probe)
+            var delta = goal - probePos
+            let l = simd_length(delta)
+            if l > maxOffset { delta *= maxOffset / l }
+            solver.setJointWorldAnchor(driver, point: probePos + delta)
+            for _ in 0..<2 { try solver.submitStep() }
+            try solver.synchronize()
+            if tick == 460 { pushedY = solver.bodyPosition(cube).y }
+        }
+
+        let finalY = solver.bodyPosition(cube).y
+        XCTAssertGreaterThan(pushedY, 0.05,
+                             "the probe should have pushed the cube")
+        // unfixed: creeps from ~0.067 back to ~0.001
+        XCTAssertGreaterThan(finalY, pushedY - 0.015,
+                             "a released object must stay where friction "
+                             + "stopped it, not creep back to where it "
+                             + "first touched down")
+        XCTAssertLessThan(
+            simd_length(solver.bodyVelocity(cube)), 0.02,
+            "and it must be at rest, not still being dragged")
+    }
+
+    /// Same invariant on the CPU backend.
+    func testPushedBoxStaysPutOnCPUBackend() throws {
+        let solver = CPUSolver()
+        solver.dt = 1.0 / 240
+        solver.iterations = 20
+        solver.betaLin = 20000
+        solver.collisionMargin = 0.003
+        solver.gravity = -9.81
+        _ = solver.addBody(size: F3(2, 2, 0.3), density: 0,
+                           friction: 1.0, position: F3(0, 0, -0.15))
+        let cube = solver.addBody(size: F3(0.11, 0.032, 0.030), density: 420,
+                                  friction: 0.30,
+                                  position: F3(0, 0, 0.017))
+
+        for _ in 0..<120 { solver.step() }
+        let rest = cube.positionLin
+
+        // shove sideways through velocity for a while, then release
+        for _ in 0..<240 {
+            cube.velocityLin.y = max(cube.velocityLin.y, 0.10)
+            solver.step()
+        }
+        let pushed = cube.positionLin.y - rest.y
+        for _ in 0..<480 { solver.step() }
+        let finalY = cube.positionLin.y - rest.y
+
+        XCTAssertGreaterThan(pushed, 0.02, "the shove should have moved it")
+        XCTAssertGreaterThan(finalY, pushed - 0.01,
+                             "no creep back toward the touchdown point")
+    }
+}


### PR DESCRIPTION
Follow-up to #7 — this is the separate friction defect flagged there ("one
change I deliberately left out"), now with a reproduction that settles the
question. I claimed there the symptom no longer reproduced on `main`; that
was wrong — my synthetic test was too weak an instrument. It reproduces
immediately with the right probe.

## The bug

The contact stick flag is only refreshed inside the **in-cone** branch of the
dual update. A contact that sticks once (any resting object) and then starts
sliding never runs that branch again, so it keeps its original friction
anchors: the tangential constraint accumulates the *entire* slide, the
applied force stays cone-capped so the push itself looks normal — and the
moment the push ends, that capped force quietly drags the object back to
where it first touched down. Every grounded object is an elastic tether to
its own touchdown point.

Measured, before the one-line fix (compliant 12 N probe pushes a resting cube
6.7 cm, then retracts):

| | final position |
|---|---|
| GPU backend | crept back to **0.6 mm** from touchdown |
| CPU backend | crept back to **0.7 mm** from touchdown |
| with fix, both | stays at 6.7 cm, at rest |

It went unnoticed for as long as every task *lifted* objects — breaking
contact resets anchors. The first pure sliding task (push a thing across a
table, let go) exposed it within minutes of play.

## Why it dodged detection before

The regression test's probe must be a **compliant, force-capped driver** (a
soft world joint whose anchor walks). A pose-teleported kinematic pusher
never reproduces the symptom — that's exactly the instrument I used when I
wrongly concluded the bug was gone. The test file records this so the next
hunt doesn't repeat it. Tests cover both backends and fail unfixed on both.

## The Arachne tolerances

`testArachneRevealIsExecutedByMotorsAndHandsBackPhysicalState` was tuned
while sliding foot contacts were tethered to their touchdown points, which
suppressed real slip during the commissioning stomp. With honest kinetic
friction the same motion drifts ~5 cm (was bounded at 4 cm) and two knees
settle at ~0.144 rad (was bounded at 0.12). The commissioning still
completes, every knee reaches the compact pose, and the robot stays upright,
so I loosened those two bounds to 0.07 m / 0.17 rad with a comment explaining
why. If you'd rather re-tune the controller than the bounds, that's the one
judgement call in this PR.

Full suite: **685 tests, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
