### PR TITLE
Fix directional-shadow banding on planar surfaces

### DIFF
--- a/Sources/AVBDApp/Renderer.swift
+++ b/Sources/AVBDApp/Renderer.swift
@@ -137,6 +137,26 @@ inline float shadowVisibility(float3 world, float3 normal,
     float slope = min(2.0, sqrt(saturate(1.0 - geomNdL * geomNdL))
                            / max(geomNdL, 0.2));
     float receiverDepth = ndc.z - (U.shadowParams.x + U.shadowParams.y * slope);
+
+    // A PCF tap does not sample the receiver at this fragment's light-space
+    // XY: it samples a neighboring shadow texel.  Reusing the center depth
+    // for every tap compares a tilted receiver against the wrong point on
+    // its own plane.  The resulting 0/1 tap-count transitions are the broad,
+    // discrete diagonal bands visible on otherwise flat boxes.  Reconstruct
+    // dz/duv from screen derivatives and compare every tap against the depth
+    // of the receiver plane at that tap instead.
+    float3 shadowCoord = float3(uv, ndc.z);
+    float3 shadowDx = dfdx(shadowCoord);
+    float3 shadowDy = dfdy(shadowCoord);
+    float determinant = shadowDx.x * shadowDy.y
+                      - shadowDx.y * shadowDy.x;
+    float2 receiverDepthGradient = float2(0.0);
+    if (abs(determinant) > 1e-10) {
+        receiverDepthGradient = float2(
+            shadowDx.z * shadowDy.y - shadowDx.y * shadowDy.z,
+            shadowDx.x * shadowDy.z - shadowDx.z * shadowDy.x)
+            / determinant;
+    }
     float2 texel = 1.0 / float2(shadowTex.get_width(), shadowTex.get_height());
     constexpr sampler shadowSampler(coord::normalized, filter::linear,
                                     address::clamp_to_edge,
@@ -144,9 +164,11 @@ inline float shadowVisibility(float3 world, float3 normal,
     float visible = 0.0;
     for (int y = -1; y <= 1; ++y) {
         for (int x = -1; x <= 1; ++x) {
+            float2 tapOffset = float2(float(x), float(y)) * texel;
+            float tapReceiverDepth = receiverDepth
+                + dot(receiverDepthGradient, tapOffset);
             visible += shadowTex.sample_compare(
-                shadowSampler, uv + float2(float(x), float(y)) * texel,
-                receiverDepth);
+                shadowSampler, uv + tapOffset, tapReceiverDepth);
         }
     }
     // A small floor keeps shaded faces readable without washing out the
@@ -1304,6 +1326,11 @@ final class Renderer: NSObject, MTKViewDelegate {
                                         height: Double(Renderer.shadowMapSize),
                                         znear: 0, zfar: 1))
             enc.setDepthStencilState(depthState)
+            // Offset caster depth in the shadow rasterizer as the primary
+            // self-shadow defense. Receiver bias alone cannot cover the
+            // sub-texel depth quantization of a sloped triangle consistently,
+            // which exposes the PCF tap count as broad tonal stripes.
+            enc.setDepthBias(1.0, slopeScale: 1.0, clamp: 0.001)
             var shadowU = U
             shadowU.viewProj = shadowVP
             if rigidCount > 0 {

--- a/Tests/AVBDTests/RendererRegressionTests.swift
+++ b/Tests/AVBDTests/RendererRegressionTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import simd
+import XCTest
+
+final class RendererRegressionTests: XCTestCase {
+    private var root: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    /// A tilted receiver has a different expected depth at every PCF tap.
+    /// Reusing the fragment-center depth exposes the number of passing taps
+    /// as visible bands; receiver-plane correction removes that quantization.
+    /// A small caster-side raster offset is still required to cover the depth
+    /// representation error at the corrected point.
+    func testPlanarPCFNeedsReceiverPlaneAndCasterBias() {
+        let centerDepth: Float = 0.5
+        let depthGradient = SIMD2<Float>(0.0020, 0.0011)
+        let representationError: Float = -0.00025
+        let receiverBias: Float = 0.00020
+        let casterRasterOffset: Float = 0.00010
+
+        func visibility(correctReceiverPlane: Bool,
+                        offsetCaster: Bool) -> Float {
+            var visible: Float = 0
+            for y in -1...1 {
+                for x in -1...1 {
+                    let tap = SIMD2<Float>(Float(x), Float(y))
+                    let planeDelta = simd_dot(depthGradient, tap)
+                    let stored = centerDepth + planeDelta
+                        + representationError
+                        + (offsetCaster ? casterRasterOffset : 0)
+                    let compared = centerDepth - receiverBias
+                        + (correctReceiverPlane ? planeDelta : 0)
+                    visible += compared <= stored ? 1 : 0
+                }
+            }
+            return visible / 9
+        }
+
+        XCTAssertLessThan(
+            visibility(correctReceiverPlane: false, offsetCaster: true), 1)
+        XCTAssertEqual(
+            visibility(correctReceiverPlane: true, offsetCaster: false), 0)
+        XCTAssertEqual(
+            visibility(correctReceiverPlane: true, offsetCaster: true), 1)
+    }
+
+    /// Renderer is an executable target, so this source contract connects the
+    /// numerical regression above to the Metal and encoder implementation.
+    func testRendererAppliesBothPlanarPCFCorrections() throws {
+        let source = try String(contentsOf: root.appendingPathComponent(
+            "Sources/AVBDApp/Renderer.swift"), encoding: .utf8)
+        XCTAssertTrue(source.contains(
+            "receiverDepthGradient, tapOffset"))
+        XCTAssertTrue(source.contains(
+            "enc.setDepthBias(1.0, slopeScale: 1.0, clamp: 0.001)"))
+    }
+}


### PR DESCRIPTION
## Summary
- evaluate each PCF tap against the corresponding point on the receiver plane instead of reusing the fragment-center depth
- add a bounded slope-aware caster raster bias to cover sub-texel depth representation error
- add a numerical regression showing that either correction alone leaves false self-shadowing, plus a source-wiring contract for the renderer

## Validation
- swift test --filter RendererRegressionTests: 2/2 passed
- make app: release build passed
- scripted release-app stack capture compiled the Metal shader and retained clean cast/contact shadows
- visually reproduced and verified in the MicroDuck policy replay scene where the diagonal bands were prominent