### PR TITLE
Engine fixes extracted from the MicroDuck branch

### DIFF
--- a/Development/Sources/Robotics/MJCFImporter.swift
+++ b/Development/Sources/Robotics/MJCFImporter.swift
@@ -313,6 +313,8 @@ public struct MJCFAsset {
         }
 
         var warnings: [String] = []
+        let visualMaterials = try loadVisualMaterials(
+            root: root, warnings: &warnings)
         let visualMeshes = loadVisualMeshes(
             root: root, baseURL: baseURL, warnings: &warnings)
 
@@ -324,7 +326,9 @@ public struct MJCFAsset {
         var jointNameSet = Set<String>()
         for body in world.children where body.name == "body" {
             try parseBody(body, parent: nil, inheritedClass: nil,
-                          defaults: defaults, visualMeshes: visualMeshes,
+                          defaults: defaults,
+                          visualMaterials: visualMaterials,
+                          visualMeshes: visualMeshes,
                           links: &links,
                           bodyNameSet: &bodyNameSet,
                           jointNameSet: &jointNameSet, warnings: &warnings)
@@ -541,7 +545,8 @@ public struct MJCFAsset {
                         localPosition: localPosition,
                         localRotation: localRotation, shape: shape,
                         collisionGroup: options.collisionGroup,
-                        collisionEnabled: false, isRendered: true)
+                        collisionEnabled: false, isRendered: true,
+                        renderColor: visual.color)
                 }
             }
         }
@@ -767,7 +772,8 @@ private func collectDefaults(_ node: XMLNode, inherited: DefaultBundle,
 
 private func parseBody(
     _ node: XMLNode, parent: Int?, inheritedClass: String?,
-    defaults: [String: DefaultBundle], visualMeshes: [String: SurfaceMesh],
+    defaults: [String: DefaultBundle], visualMaterials: [String: F3],
+    visualMeshes: [String: SurfaceMesh],
     links: inout [Link],
     bodyNameSet: inout Set<String>, jointNameSet: inout Set<String>,
     warnings: inout [String]
@@ -856,7 +862,7 @@ private func parseBody(
             if let meshName = attrs["mesh"],
                let mesh = visualMeshes[meshName] {
                 visualGeometries.append(try parseVisualGeometry(
-                    attrs, kind: .mesh(mesh)))
+                    attrs, kind: .mesh(mesh), materials: visualMaterials))
             } else if let meshName = attrs["mesh"] {
                 warnings.append("visual mesh \(meshName) is unavailable")
             }
@@ -867,6 +873,7 @@ private func parseBody(
                 attrs, bodyName: name, warnings: &warnings)
             visualGeometries.append(try parseVisualGeometry(
                 attrs, kind: .primitive(primitive.shape, primitive.size),
+                materials: visualMaterials,
                 position: primitive.position, rotation: primitive.rotation))
             continue
         }
@@ -881,7 +888,9 @@ private func parseBody(
                       visualGeometries: visualGeometries))
     for child in node.children where child.name == "body" {
         try parseBody(child, parent: index, inheritedClass: activeClass,
-                      defaults: defaults, visualMeshes: visualMeshes,
+                      defaults: defaults,
+                      visualMaterials: visualMaterials,
+                      visualMeshes: visualMeshes,
                       links: &links,
                       bodyNameSet: &bodyNameSet, jointNameSet: &jointNameSet,
                       warnings: &warnings)
@@ -964,18 +973,74 @@ private func parseCollisionGeometry(
 
 private func parseVisualGeometry(
     _ attrs: [String: String], kind: VisualGeometryKind,
+    materials: [String: F3],
     position: F3? = nil, rotation: Quat? = nil
 ) throws -> VisualGeometry {
-    let rgba = try floatList(attrs["rgba"] ?? "0.24 0.28 0.34 1",
-                             minimumCount: 3, element: "geom",
-                             attribute: "rgba")
+    let color: F3
+    if let rawRGBA = attrs["rgba"] {
+        // MuJoCo gives a local/default-class rgba precedence over a referenced
+        // material. Preserve that rule instead of blindly applying the asset.
+        let rgba = try colorComponents(
+            rawRGBA, element: "geom", attribute: "rgba")
+        color = F3(rgba[0], rgba[1], rgba[2])
+    } else if let name = attrs["material"] {
+        guard let material = materials[name] else {
+            throw MJCFImportError.missing(
+                "visual geom references material \(name)")
+        }
+        color = material
+    } else {
+        // Retain AVBD's established unmaterialed-CAD fallback.
+        color = F3(0.24, 0.28, 0.34)
+    }
     return VisualGeometry(
         kind: kind,
         position: try position ?? vector3(
             attrs["pos"] ?? "0 0 0", element: "geom", attribute: "pos"),
         rotation: try rotation ?? quaternion(
             attrs["quat"] ?? "1 0 0 0", element: "geom", attribute: "quat"),
-        color: F3(rgba[0], rgba[1], rgba[2]))
+        color: color)
+}
+
+/// Resolve named MJCF materials once at the asset boundary. SurfaceMesh is a
+/// position/normal STL representation and therefore has no UV channel; models
+/// that reference a texture keep their material tint and report the omitted
+/// texture explicitly rather than silently turning black.
+private func loadVisualMaterials(
+    root: XMLNode, warnings: inout [String]
+) throws -> [String: F3] {
+    guard let assets = root.children.first(where: { $0.name == "asset" }) else {
+        return [:]
+    }
+    var result: [String: F3] = [:]
+    for node in assets.children where node.name == "material" {
+        let name = try required(node, "name")
+        guard result[name] == nil else {
+            throw MJCFImportError.unsupported(
+                "duplicate visual material \(name)")
+        }
+        let rgba = try colorComponents(
+            node.attributes["rgba"] ?? "1 1 1 1",
+            element: "material", attribute: "rgba")
+        result[name] = F3(rgba[0], rgba[1], rgba[2])
+        if node.attributes["texture"] != nil {
+            warnings.append(
+                "visual material \(name) texture is unavailable; using rgba")
+        }
+    }
+    return result
+}
+
+private func colorComponents(
+    _ value: String, element: String, attribute: String
+) throws -> [Float] {
+    let rgba = try floatList(
+        value, count: 4, element: element, attribute: attribute)
+    guard rgba.allSatisfy({ $0.isFinite && (0...1).contains($0) }) else {
+        throw MJCFImportError.invalidAttribute(
+            element: element, attribute: attribute, value: value)
+    }
+    return rgba
 }
 
 /// Load available visual assets without making rendering geometry a physics

--- a/Development/Sources/Robotics/MJCFImporter.swift
+++ b/Development/Sources/Robotics/MJCFImporter.swift
@@ -524,7 +524,8 @@ public struct MJCFAsset {
                     // proxies stay inspectable in assets without being drawn
                     // through the detailed surface.
                     isRendered: !options.includeVisuals
-                        || link.visualGeometries.isEmpty)
+                        || link.visualGeometries.isEmpty,
+                    renderColor: geom.renderColor)
             }
             for visual in options.includeVisuals
                 ? link.visualGeometries : [] {
@@ -729,6 +730,9 @@ private struct CollisionGeometry {
     var friction: Float
     var boundingRadius: Float
     var collisionEnabled: Bool
+    /// Authored `rgba` or named material, when the geom has one. Nil keeps
+    /// the renderer's per-body fallback for uncolored contact geometry.
+    var renderColor: F3?
 }
 
 private enum VisualGeometryKind {
@@ -870,7 +874,8 @@ private func parseBody(
         }
         if isVisualOnly {
             let primitive = try parseCollisionGeometry(
-                attrs, bodyName: name, warnings: &warnings)
+                attrs, bodyName: name, materials: visualMaterials,
+                warnings: &warnings)
             visualGeometries.append(try parseVisualGeometry(
                 attrs, kind: .primitive(primitive.shape, primitive.size),
                 materials: visualMaterials,
@@ -878,7 +883,8 @@ private func parseBody(
             continue
         }
         geometries.append(try parseCollisionGeometry(
-            attrs, bodyName: name, warnings: &warnings))
+            attrs, bodyName: name, materials: visualMaterials,
+            warnings: &warnings))
     }
 
     let index = links.count
@@ -898,9 +904,11 @@ private func parseBody(
 }
 
 private func parseCollisionGeometry(
-    _ attrs: [String: String], bodyName: String, warnings: inout [String]
+    _ attrs: [String: String], bodyName: String, materials: [String: F3],
+    warnings: inout [String]
 ) throws -> CollisionGeometry {
     let type = attrs["type"] ?? "sphere"
+    let renderColor = try authoredColor(attrs, materials: materials)
     let friction = try floatList(attrs["friction"] ?? "1 0.005 0.0001",
                                  minimumCount: 1, element: "geom",
                                  attribute: "friction")[0]
@@ -968,7 +976,8 @@ private func parseCollisionGeometry(
     return CollisionGeometry(shape: shape, size: size, position: position,
                              rotation: rotation, friction: friction,
                              boundingRadius: radius,
-                             collisionEnabled: collisionEnabled)
+                             collisionEnabled: collisionEnabled,
+                             renderColor: renderColor)
 }
 
 private func parseVisualGeometry(
@@ -976,23 +985,9 @@ private func parseVisualGeometry(
     materials: [String: F3],
     position: F3? = nil, rotation: Quat? = nil
 ) throws -> VisualGeometry {
-    let color: F3
-    if let rawRGBA = attrs["rgba"] {
-        // MuJoCo gives a local/default-class rgba precedence over a referenced
-        // material. Preserve that rule instead of blindly applying the asset.
-        let rgba = try colorComponents(
-            rawRGBA, element: "geom", attribute: "rgba")
-        color = F3(rgba[0], rgba[1], rgba[2])
-    } else if let name = attrs["material"] {
-        guard let material = materials[name] else {
-            throw MJCFImportError.missing(
-                "visual geom references material \(name)")
-        }
-        color = material
-    } else {
-        // Retain AVBD's established unmaterialed-CAD fallback.
-        color = F3(0.24, 0.28, 0.34)
-    }
+    // Retain AVBD's established unmaterialed-CAD fallback.
+    let color = try authoredColor(attrs, materials: materials)
+        ?? F3(0.24, 0.28, 0.34)
     return VisualGeometry(
         kind: kind,
         position: try position ?? vector3(
@@ -1000,6 +995,30 @@ private func parseVisualGeometry(
         rotation: try rotation ?? quaternion(
             attrs["quat"] ?? "1 0 0 0", element: "geom", attribute: "quat"),
         color: color)
+}
+
+/// The color a geom authors, or nil when it has neither `rgba` nor a
+/// `material`. Shared by rendered collision primitives and visual-only geoms
+/// so a named material colors an ordinary MJCF geom that both collides and
+/// renders, not only one with zeroed contact masks.
+private func authoredColor(
+    _ attrs: [String: String], materials: [String: F3]
+) throws -> F3? {
+    if let rawRGBA = attrs["rgba"] {
+        // MuJoCo gives a local/default-class rgba precedence over a referenced
+        // material. Preserve that rule instead of blindly applying the asset.
+        let rgba = try colorComponents(
+            rawRGBA, element: "geom", attribute: "rgba")
+        return F3(rgba[0], rgba[1], rgba[2])
+    }
+    if let name = attrs["material"] {
+        guard let material = materials[name] else {
+            throw MJCFImportError.missing(
+                "geom references material \(name)")
+        }
+        return material
+    }
+    return nil
 }
 
 /// Resolve named MJCF materials once at the asset boundary. SurfaceMesh is a

--- a/Development/Tests/AVBDTests/MJCFImporterTests.swift
+++ b/Development/Tests/AVBDTests/MJCFImporterTests.swift
@@ -71,6 +71,47 @@ final class MJCFImporterTests: XCTestCase {
         }
     }
 
+    func testNamedMaterialColorsRenderedCollisionPrimitives() throws {
+        let xml = """
+        <mujoco model="collision-material-fixture">
+          <asset>
+            <material name="shell" rgba="0.9 0.2 0.1 1"/>
+          </asset>
+          <default>
+            <default class="shell-part">
+              <geom material="shell"/>
+            </default>
+          </default>
+          <worldbody>
+            <body name="root">
+              <inertial mass="1" diaginertia="1 1 1"/>
+              <geom type="sphere" size="0.1" material="shell"/>
+              <geom class="shell-part" type="sphere" size="0.1"
+                    pos="1 0 0"/>
+              <geom type="box" size="0.1 0.1 0.1" pos="2 0 0"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        let asset = try MJCFAsset.parse(data: Data(xml.utf8))
+        var scene = PhysicsScene(name: "collision-material-fixture")
+        _ = try asset.instantiate(
+            in: &scene, options: MJCFInstantiationOptions())
+
+        XCTAssertEqual(scene.colliders.count, 3)
+        // Ordinary geoms collide and render; a material must reach them the
+        // same way it reaches visual-only primitives.
+        for index in 0..<2 {
+            XCTAssertTrue(scene.colliders[index].collisionEnabled)
+            XCTAssertTrue(scene.colliders[index].isRendered)
+            XCTAssertLessThan(simd_length(
+                try XCTUnwrap(scene.colliders[index].renderColor)
+                    - F3(0.9, 0.2, 0.1)), 1e-6)
+        }
+        // Uncolored contact geometry keeps the renderer's per-body fallback.
+        XCTAssertNil(scene.colliders[2].renderColor)
+    }
+
     func testInstantiationOptionsApplyCombinedConfiguration() throws {
         let xml = """
         <mujoco model="options-fixture">

--- a/Development/Tests/AVBDTests/MJCFImporterTests.swift
+++ b/Development/Tests/AVBDTests/MJCFImporterTests.swift
@@ -27,6 +27,50 @@ final class MJCFImporterTests: XCTestCase {
         XCTAssertTrue(options.includeVisuals)
     }
 
+    func testNamedMaterialColorsReachMeshAndPrimitiveVisuals() throws {
+        let xml = """
+        <mujoco model="material-fixture">
+          <asset>
+            <material name="body-yellow" rgba="0.98 0.71 0.004 1"/>
+            <material name="accent-teal" rgba="0.54 0.85 0.83 1"/>
+          </asset>
+          <worldbody>
+            <body name="root">
+              <inertial mass="1" diaginertia="1 1 1"/>
+              <geom type="sphere" size="0.1" contype="0" conaffinity="0"
+                    material="body-yellow"/>
+              <geom type="sphere" size="0.1" pos="1 0 0"
+                    contype="0" conaffinity="0" material="body-yellow"
+                    rgba="0.54 0.85 0.83 1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        let asset = try MJCFAsset.parse(data: Data(xml.utf8))
+        var scene = PhysicsScene(name: "material-fixture")
+        _ = try asset.instantiate(
+            in: &scene, options: MJCFInstantiationOptions())
+
+        XCTAssertEqual(scene.colliders.count, 2)
+        XCTAssertLessThan(simd_length(
+            try XCTUnwrap(scene.colliders[0].renderColor)
+                - F3(0.98, 0.71, 0.004)), 1e-6)
+        // A local rgba has the same precedence as MuJoCo, including when a
+        // named material is also present.
+        XCTAssertLessThan(simd_length(
+            try XCTUnwrap(scene.colliders[1].renderColor)
+                - F3(0.54, 0.85, 0.83)), 1e-6)
+
+        let missing = xml.replacingOccurrences(
+            of: "material=\"body-yellow\"/>",
+            with: "material=\"missing\"/>",
+            options: [], range: xml.range(of: "material=\"body-yellow\"/>"))
+        XCTAssertThrowsError(try MJCFAsset.parse(data: Data(missing.utf8))) {
+            XCTAssertTrue(String(describing: $0).contains(
+                "references material missing"))
+        }
+    }
+
     func testInstantiationOptionsApplyCombinedConfiguration() throws {
         let xml = """
         <mujoco model="options-fixture">

--- a/Sources/GPUSimDemos/SoftMeshSkinning+Demos.swift
+++ b/Sources/GPUSimDemos/SoftMeshSkinning+Demos.swift
@@ -518,7 +518,15 @@ extension Demos {
                 tet(c000, c110, c101, c011)
             }
         }
-        for (key, a) in nodeId {
+        // Dictionary iteration is process-randomized. These inert neighbor
+        // exclusions participate in graph construction, so random insertion
+        // order changes body colors and can send the same contact-rich replay
+        // down a different numerical trajectory on each launch.
+        let orderedKeys = nodeId.keys.sorted {
+            ($0.x, $0.y, $0.z) < ($1.x, $1.y, $1.z)
+        }
+        for key in orderedKeys {
+            let a = nodeId[key]!
             for d in [SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1),
                       SIMD3(1, 1, 0), SIMD3(1, 0, 1), SIMD3(0, 1, 1),
                       SIMD3(1, 1, 1)] {

--- a/Sources/GPUSimRenderer/GPUSimRenderer.swift
+++ b/Sources/GPUSimRenderer/GPUSimRenderer.swift
@@ -565,6 +565,37 @@ inline float3 acesTonemap(float3 x) {
     return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
 }
 
+// The drawable is an 8-bit sRGB target. A smooth near-white lighting ramp
+// can otherwise collapse into wide one-code plateaus after tone mapping.
+// Dither in encoded sRGB space, then return to linear so the attachment's
+// hardware conversion produces the intended sub-LSB distribution. The noise
+// is deterministic in screen space, zero-mean, and cannot shimmer over time.
+inline float3 linearToSRGBExact(float3 c) {
+    c = clamp(c, 0.0, 1.0);
+    float3 low = c * 12.92;
+    float3 high = 1.055 * pow(c, float3(1.0 / 2.4)) - 0.055;
+    return select(low, high, c > 0.0031308);
+}
+
+inline float3 sRGBToLinearExact(float3 c) {
+    c = clamp(c, 0.0, 1.0);
+    float3 low = c / 12.92;
+    float3 high = pow((c + 0.055) / 1.055, float3(2.4));
+    return select(low, high, c > 0.04045);
+}
+
+inline float interleavedGradientNoise(float2 pixel) {
+    float2 p = floor(pixel);
+    return fract(52.9829189 * fract(dot(p, float2(0.06711056, 0.00583715))));
+}
+
+inline float3 displayColorSRGB8(float3 toneMappedLinear, float2 pixel) {
+    float noise = interleavedGradientNoise(pixel) - 0.5;
+    float3 encoded = linearToSRGBExact(toneMappedLinear);
+    encoded = clamp(encoded + noise / 255.0, 0.0, 1.0);
+    return sRGBToLinearExact(encoded);
+}
+
 // Three-by-three comparison-filtered directional shadow. The light projection
 // follows the camera target, so the useful texel density stays around the robot
 // instead of being spent on the effectively infinite floor.
@@ -912,7 +943,7 @@ fragment float4 pbr_fragment(VOut in [[stage_in]],
     float3 lit = direct + ambient + in.emissive;
     float fog = horizonFog(length(in.world - U.eye.xyz));
     lit = mix(lit, HORIZON_LIN, fog);
-    return float4(acesTonemap(lit), in.opacity);
+    return float4(displayColorSRGB8(acesTonemap(lit), in.position.xy), in.opacity);
 }
 
 // ---------------------------------------------------------------------------
@@ -975,7 +1006,7 @@ fragment float4 soft_fragment(VOut in [[stage_in]],
     float3 lit = direct + ambient + in.emissive;
     float fog = horizonFog(length(in.world - U.eye.xyz));
     lit = mix(lit, HORIZON_LIN, fog);
-    return float4(acesTonemap(lit), in.opacity);
+    return float4(displayColorSRGB8(acesTonemap(lit), in.position.xy), in.opacity);
 }
 
 // Prepass variant: only the FRONT layer reaches the AO/depth buffers. The
@@ -1288,7 +1319,7 @@ fragment float4 sky_fragment(FSOut in [[stage_in]]) {
     float2 ndc = float2(in.uv.x * 2.0 - 1.0, 1.0 - in.uv.y * 2.0);
     float glow = exp(-3.0 * distance(ndc, float2(-0.45, 0.55)));
     c += float3(0.30, 0.25, 0.16) * glow;
-    return float4(acesTonemap(c), 1);
+    return float4(displayColorSRGB8(acesTonemap(c), in.position.xy), 1);
 }
 
 struct FloorOut { float4 position [[position]]; float3 world; };
@@ -1349,7 +1380,7 @@ fragment float4 floor_fragment(FloorOut in [[stage_in]],
 
     float fog = horizonFog(d);
     lit = mix(lit, HORIZON_LIN, fog);
-    return float4(acesTonemap(lit), 1);
+    return float4(displayColorSRGB8(acesTonemap(lit), in.position.xy), 1);
 }
 
 """

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -1153,6 +1153,9 @@ public final class GPUSolver {
         precondition(scene.settings.collisionMargin >= 0
             && scene.settings.collisionMargin.isFinite,
             "collision margin must be finite and nonnegative")
+        precondition(scene.settings.deformableCollisionMargin.map {
+            $0 > 0 && $0.isFinite
+        } ?? true, "deformable collision margin must be finite and positive")
         precondition(scene.settings.rigidLinearDamping >= 0
             && scene.settings.rigidLinearDamping.isFinite
             && scene.settings.rigidAngularDamping >= 0
@@ -2858,7 +2861,8 @@ public final class GPUSolver {
             edgeLenSum += distance(a.position, b.position)
         }
         let meanEdge = topoEdgeKeys.isEmpty ? 0.2 : edgeLenSum / Float(topoEdgeKeys.count)
-        params.elemMargin = min(0.01, max(0.002, 0.5 * maxPartR))
+        params.elemMargin = settings.deformableCollisionMargin
+            ?? min(0.01, max(0.002, 0.5 * maxPartR))
         // Planar-DAT queries a wider safety neighborhood than the active
         // OGC force band. Anything beyond this radius is protected by the
         // unconditional 0.5*gamma*rq accumulated-displacement cap.

--- a/Sources/SimCore/Scenes/Scene.swift
+++ b/Sources/SimCore/Scenes/Scene.swift
@@ -544,6 +544,12 @@ public struct SimSettings {
     /// This is also the rigid-contact equilibrium skin, so an oversized value
     /// visibly permits geometry to settle below the rendered surface.
     public var collisionMargin: Float = 0.01
+    /// Optional contact slop for deformable V-T, E-E, and rigid-triangle
+    /// constraints. `nil` preserves the legacy radius-scaled 2 mm...1 cm
+    /// heuristic. Small-scale manipulation scenes can choose a tighter value
+    /// without shrinking the rigid broadphase margin for the whole robot.
+    /// Must be finite and strictly positive when set.
+    public var deformableCollisionMargin: Float? = nil
     public var frictionCombineMode: FrictionCombineMode = .geometricMean
     public var alpha: Float = 0.99
     // 10000 matches the reference avbd-demo3d default (its in-code note

--- a/Tests/GPUSimRendererTests/RendererRegressionTests.swift
+++ b/Tests/GPUSimRendererTests/RendererRegressionTests.swift
@@ -59,4 +59,49 @@ final class RendererRegressionTests: XCTestCase {
         XCTAssertTrue(source.contains(
             "enc.setDepthBias(1.0, slopeScale: 1.0, clamp: 0.001)"))
     }
+
+    /// An 8-bit target cannot represent a tone halfway between adjacent sRGB
+    /// codes.  Repeating the same rounded code creates a visible contour;
+    /// deterministic sub-LSB dithering represents the tone in the local
+    /// spatial average instead.
+    func testSRGBDitherRepresentsSubCodeTone() {
+        let lowerCode = 224
+        let targetEncoded = (Float(lowerCode) + 0.42) / 255
+
+        func noise(x: Int, y: Int) -> Float {
+            func fract(_ value: Float) -> Float {
+                value - floor(value)
+            }
+            let inner = fract(Float(x) * 0.06711056 + Float(y) * 0.00583715)
+            return fract(52.9829189 * inner) - 0.5
+        }
+
+        func quantized(_ encoded: Float) -> Float {
+            round(max(0, min(encoded, 1)) * 255) / 255
+        }
+
+        let undithered = quantized(targetEncoded)
+        var ditheredMean: Float = 0
+        let side = 64
+        for y in 0..<side {
+            for x in 0..<side {
+                ditheredMean += quantized(
+                    targetEncoded + noise(x: x, y: y) / 255)
+            }
+        }
+        ditheredMean /= Float(side * side)
+
+        XCTAssertGreaterThan(abs(undithered - targetEncoded), 0.35 / 255)
+        XCTAssertLessThan(abs(ditheredMean - targetEncoded), 0.03 / 255)
+    }
+
+    func testRendererDithersFinalToneMappedColorForSRGB8() throws {
+        let source = try String(contentsOf: root.appendingPathComponent(
+            "Sources/GPUSimRenderer/GPUSimRenderer.swift"), encoding: .utf8)
+        XCTAssertTrue(source.contains("inline float3 displayColorSRGB8"))
+        XCTAssertEqual(
+            source.components(separatedBy: "displayColorSRGB8(acesTonemap(").count - 1,
+            4)
+        XCTAssertTrue(source.contains("static let colorFormat = MTLPixelFormat.bgra8Unorm_srgb"))
+    }
 }


### PR DESCRIPTION
## Summary

Five generic changes lifted out of the uncommitted work on `codex/microduck-policy-replay`. Everything MicroDuck-specific (policy bundle runtime, sim2sim env, checkpoint bundle, Makefile staging, notices) stays on that branch.

- **MJCF named materials.** `<material>` assets now resolve to visual colors. A local `rgba` keeps MuJoCo's precedence over the material, a texture-only material warns and keeps its tint, and an unknown material is an import error. This also fixes a latent bug: primitive visual geoms never passed their color to the collider and drew with the fallback tint. Mesh visuals were already correct.
- **sRGB sub-LSB dither.** The final tone-mapped color is dithered in encoded sRGB space with deterministic interleaved-gradient noise, then returned to linear so the `bgra8Unorm_srgb` attachment's hardware conversion lands on the intended distribution. Removes banding on near-white lighting ramps. Applied in all four fragment entry points; zero-mean and static in screen space, so it cannot shimmer.
- **`SimSettings.deformableCollisionMargin`.** Optional override for the radius-scaled deformable contact slop (V-T, E-E, rigid-triangle). `nil` keeps the legacy 2 mm to 1 cm heuristic, so existing scenes are unchanged. The GPU solver rejects a non-positive or non-finite value with a precondition. GPU-only by design: the CPU solver has no deformable path.
- **Deterministic tet-graph ordering.** Skinned soft-mesh graph construction iterated a dictionary, so neighbor-exclusion insertion order, body colors, and contact trajectories varied per launch. Keys are now sorted.
- **Renderer regression tests** for the dither's sub-LSB tone behaviour and for all four shaders routing through it.

## Deliberately left out

- The crease-aware STL normals rebuild. It changes the default look of every STL through the MJCF importer (arachne15 today) and its tests live in a separate worktree. Will follow once consolidated and eyeballed.
- The cloth portal-retry cap change in `25_cloth.metal`. It widens recovery for nearly every existing cloth and Planar-DAT scene, not just sub-millimeter ones, and has no test yet.
- `SoftMeshRenderMode`. No callers anywhere yet.

## Test plan

- [x] `swift build` (root) and `swift build --package-path Development`
- [x] Root: `RendererRegressionTests`, `GPUSimRendererTests`, `SoftBodyTests`, `ClothTests` (31 tests, 0 failures)
- [x] Development: `MJCFImporterTests` including the new `testNamedMaterialColorsReachMeshAndPrimitiveVisuals` (13 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
