### PR TITLE
Tet compaction stiffening for plush-like soft bodies (opt-in)

### DIFF
--- a/Sources/GPUSimDemos/SkinBindGPU.swift
+++ b/Sources/GPUSimDemos/SkinBindGPU.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Metal
+import simd
+import SimCore
+
+/// Hash-grid skin binding on the GPU. One thread per visual vertex walks the
+/// cage's tet grid outward from its (clamped) cell, evaluates barycentric
+/// coordinates in every candidate tet with the cage's precomputed inverse
+/// rest matrices, and keeps the same best-candidate rule as the serial
+/// binder: an enclosing tet first, then the smallest reconstruction error,
+/// then the smallest barycentric excursion. The serial walk cost ~24 s for
+/// 300k vertices in a debug build; this is a few milliseconds.
+final class SkinBindGPU {
+    static let shared: SkinBindGPU? = SkinBindGPU()
+
+    private let device: MTLDevice
+    private let queue: MTLCommandQueue
+    private let pipeline: MTLComputePipelineState
+
+    private struct Params {
+        var origin: SIMD3<Float>
+        var cellSize: Float
+        var dims: SIMD3<UInt32>
+        var recordCount: UInt32
+        var vertexCount: UInt32
+        var maxRing: UInt32
+        var pad0: UInt32 = 0
+        var pad1: UInt32 = 0
+    }
+
+    private struct Pick {
+        var record: UInt32
+        var pad: SIMD3<UInt32>
+        var weights: SIMD4<Float>
+    }
+
+    private static let source = """
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct Params {
+        float3 origin;
+        float cellSize;
+        uint3 dims;
+        uint recordCount;
+        uint vertexCount;
+        uint maxRing;
+        uint pad0;
+        uint pad1;
+    };
+
+    struct Pick {
+        uint record;
+        uint3 pad;
+        float4 weights;
+    };
+
+    struct Best {
+        uint record;
+        float4 w;
+        bool inside;
+        float dist2;
+        float outside;
+        bool valid;
+    };
+
+    inline void consider(uint ti,
+                         float3 p,
+                         device const float4* x0,
+                         device const float4* x1,
+                         device const float4* x2,
+                         device const float4* x3,
+                         device const float4* inv0,
+                         device const float4* inv1,
+                         device const float4* inv2,
+                         thread Best& best)
+    {
+        float3 d = p - x0[ti].xyz;
+        float3 u = float3(dot(inv0[ti].xyz, d), dot(inv1[ti].xyz, d),
+                          dot(inv2[ti].xyz, d));
+        float4 w = float4(1.0f - u.x - u.y - u.z, u.x, u.y, u.z);
+        float minW = min(min(w.x, w.y), min(w.z, w.w));
+        float outside = max(0.0f, -minW);
+        bool inside = outside <= 1e-4f;
+        float4 wc = max(w, float4(0.0f));
+        float sum = wc.x + wc.y + wc.z + wc.w;
+        wc = sum <= 1e-12f ? float4(0.25f) : wc / sum;
+        float3 q = x0[ti].xyz * wc.x + x1[ti].xyz * wc.y
+                 + x2[ti].xyz * wc.z + x3[ti].xyz * wc.w;
+        float d2 = length_squared(q - p);
+        if (!best.valid
+            || (inside && !best.inside)
+            || (inside == best.inside && d2 < best.dist2)
+            || (inside == best.inside && d2 == best.dist2
+                && outside < best.outside)) {
+            best.record = ti; best.w = w; best.inside = inside;
+            best.dist2 = d2; best.outside = outside; best.valid = true;
+        }
+    }
+
+    kernel void skin_bind(
+        device const float4* vertices  [[buffer(0)]],
+        device const float4* x0        [[buffer(1)]],
+        device const float4* x1        [[buffer(2)]],
+        device const float4* x2        [[buffer(3)]],
+        device const float4* x3        [[buffer(4)]],
+        device const float4* inv0      [[buffer(5)]],
+        device const float4* inv1      [[buffer(6)]],
+        device const float4* inv2      [[buffer(7)]],
+        device const uint* cellStart   [[buffer(8)]],
+        device const uint* cellItems   [[buffer(9)]],
+        constant Params& P             [[buffer(10)]],
+        device Pick* picks             [[buffer(11)]],
+        uint gid                       [[thread_position_in_grid]])
+    {
+        if (gid >= P.vertexCount) return;
+        float3 p = vertices[gid].xyz;
+        float3 q = (p - P.origin) / P.cellSize;
+        int3 dims = int3(P.dims);
+        int3 c = clamp(int3(floor(q)), int3(0), dims - 1);
+        Best best;
+        best.valid = false;
+        for (uint r = 0; r <= P.maxRing && !best.valid; r++) {
+            int ri = int(r);
+            int3 mn = max(c - ri, int3(0));
+            int3 mx = min(c + ri, dims - 1);
+            for (int i = mn.x; i <= mx.x; i++)
+            for (int j = mn.y; j <= mx.y; j++)
+            for (int k = mn.z; k <= mx.z; k++) {
+                uint cell = uint((k * dims.y + j) * dims.x + i);
+                uint s = cellStart[cell], e = cellStart[cell + 1];
+                for (uint idx = s; idx < e; idx++) {
+                    consider(cellItems[idx], p, x0, x1, x2, x3,
+                             inv0, inv1, inv2, best);
+                }
+            }
+        }
+        if (!best.valid) {
+            for (uint ti = 0; ti < P.recordCount; ti++) {
+                consider(ti, p, x0, x1, x2, x3, inv0, inv1, inv2, best);
+            }
+        }
+        Pick pick;
+        pick.record = best.valid ? best.record : 0u;
+        pick.pad = uint3(0);
+        pick.weights = best.valid ? best.w : float4(0.25f);
+        picks[gid] = pick;
+    }
+    """
+
+    private init?() {
+        guard let device = MTLCreateSystemDefaultDevice(),
+              let queue = device.makeCommandQueue(),
+              let library = try? device.makeLibrary(source: Self.source, options: nil),
+              let function = library.makeFunction(name: "skin_bind"),
+              let pipeline = try? device.makeComputePipelineState(function: function)
+        else { return nil }
+        self.device = device
+        self.queue = queue
+        self.pipeline = pipeline
+    }
+
+    func bind(mesh: SurfaceMesh, index: Demos.TetBindIndex) -> [Demos.SkinBindPick]? {
+        let records = index.records
+        guard !records.isEmpty, !mesh.vertices.isEmpty else { return nil }
+        func buffer<T>(_ values: [T]) -> MTLBuffer? {
+            values.withUnsafeBytes { raw in
+                device.makeBuffer(bytes: raw.baseAddress!, length: max(16, raw.count),
+                                  options: .storageModeShared)
+            }
+        }
+        func pad(_ v: SIMD3<Float>) -> SIMD4<Float> { SIMD4(v, 0) }
+        let cellCount = index.dims.x * index.dims.y * index.dims.z
+        var cellStart = [UInt32](repeating: 0, count: cellCount + 1)
+        var cellItems: [UInt32] = []
+        for cell in 0..<cellCount {
+            cellStart[cell] = UInt32(cellItems.count)
+            cellItems.append(contentsOf: index.cells[cell].map(UInt32.init))
+        }
+        cellStart[cellCount] = UInt32(cellItems.count)
+        guard let vertexBuf = buffer(mesh.vertices.map(pad)),
+              let x0 = buffer(records.map { pad($0.x0) }),
+              let x1 = buffer(records.map { pad($0.x1) }),
+              let x2 = buffer(records.map { pad($0.x2) }),
+              let x3 = buffer(records.map { pad($0.x3) }),
+              let inv0 = buffer(records.map { pad($0.restInv0) }),
+              let inv1 = buffer(records.map { pad($0.restInv1) }),
+              let inv2 = buffer(records.map { pad($0.restInv2) }),
+              let startBuf = buffer(cellStart),
+              let itemsBuf = buffer(cellItems.isEmpty ? [0] : cellItems),
+              let picksBuf = device.makeBuffer(
+                length: mesh.vertices.count * MemoryLayout<Pick>.stride,
+                options: .storageModeShared),
+              let command = queue.makeCommandBuffer(),
+              let encoder = command.makeComputeCommandEncoder()
+        else { return nil }
+        var params = Params(
+            origin: index.origin, cellSize: index.cellSize,
+            dims: SIMD3(UInt32(index.dims.x), UInt32(index.dims.y), UInt32(index.dims.z)),
+            recordCount: UInt32(records.count),
+            vertexCount: UInt32(mesh.vertices.count), maxRing: 12)
+        encoder.setComputePipelineState(pipeline)
+        for (slot, buf) in [vertexBuf, x0, x1, x2, x3, inv0, inv1, inv2, startBuf, itemsBuf].enumerated() {
+            encoder.setBuffer(buf, offset: 0, index: slot)
+        }
+        encoder.setBytes(&params, length: MemoryLayout<Params>.stride, index: 10)
+        encoder.setBuffer(picksBuf, offset: 0, index: 11)
+        let width = min(pipeline.maxTotalThreadsPerThreadgroup, 256)
+        encoder.dispatchThreadgroups(
+            MTLSize(width: (mesh.vertices.count + width - 1) / width, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1))
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+        guard command.error == nil else { return nil }
+        let out = picksBuf.contents().bindMemory(to: Pick.self, capacity: mesh.vertices.count)
+        return (0..<mesh.vertices.count).map {
+            Demos.SkinBindPick(record: Int(out[$0].record), weights: out[$0].weights)
+        }
+    }
+}

--- a/Sources/GPUSimDemos/SoftMeshSkinning+Demos.swift
+++ b/Sources/GPUSimDemos/SoftMeshSkinning+Demos.swift
@@ -635,7 +635,7 @@ extension Demos {
                       position: F3(0, halfY + thickness * 0.5, z))
     }
 
-    private struct TetBindRecord {
+    struct TetBindRecord {
         var ids: (Int, Int, Int, Int)
         var x0: F3
         var x1: F3
@@ -673,7 +673,7 @@ extension Demos {
         }
     }
 
-    private struct TetBindIndex {
+    struct TetBindIndex {
         var records: [TetBindRecord]
         var origin: F3 = .zero
         var cellSize: Float = 1
@@ -725,7 +725,13 @@ extension Demos {
 
         func candidates(near p: F3, maxRing: Int) -> [Int] {
             guard !records.isEmpty else { return [] }
-            let c = coord(p)
+            // Clamp into the grid so a point outside the cage (a dressed
+            // skin larger than its cage) searches from the nearest cage
+            // cells instead of needing rings wide enough to reach them.
+            let raw = coord(p)
+            let c = SIMD3(min(max(raw.x, 0), dims.x - 1),
+                          min(max(raw.y, 0), dims.y - 1),
+                          min(max(raw.z, 0), dims.z - 1))
             var seen = Set<Int>()
             var out: [Int] = []
             for r in 0...max(0, maxRing) {
@@ -749,19 +755,59 @@ extension Demos {
         }
     }
 
-    private static func bindVisualMesh(_ mesh: SurfaceMesh,
-                                       scene: PhysicsScene,
-                                       tetRange: Range<Int>,
-                                       bodyIDs: [Int]) -> SceneSkinnedMesh {
+    /// Bind a visual surface to an existing tetrahedral cage: every vertex
+    /// takes barycentric weights in its containing (or nearest) tet of
+    /// `tetRange`. Public so task builders can dress an authored cage.
+    public static func bindVisualMesh(_ mesh: SurfaceMesh,
+                                      scene: PhysicsScene,
+                                      tetRange: Range<Int>,
+                                      bodyIDs: [Int]) -> SceneSkinnedMesh {
         let index = TetBindIndex(tets: tetRange.map { scene.tets[$0] },
                                  scene: scene)
+        guard !index.records.isEmpty else {
+            return SceneSkinnedMesh(vertices: [], triangles: mesh.triangles,
+                                    bodyIDs: bodyIDs)
+        }
+        // Binding is a per-vertex nearest-tet search over a hash grid: it is
+        // embarrassingly parallel, so run it as a compute kernel and keep the
+        // serial walk only as the no-Metal fallback.
+        let picks = SkinBindGPU.shared?.bind(mesh: mesh, index: index)
+            ?? bindVisualMeshCPU(mesh, index: index)
         var vertices: [SceneSkinnedVertex] = []
         vertices.reserveCapacity(mesh.vertices.count)
-        for (vi, p) in mesh.vertices.enumerated() {
-            var best: (record: TetBindRecord, w: SIMD4<Float>, inside: Bool,
+        for (vi, pick) in picks.enumerated() {
+            let record = index.records[pick.record]
+            vertices.append(SceneSkinnedVertex(ids: record.ids,
+                                               weights: pick.weights,
+                                               restNormal: mesh.normals[vi],
+                                               restInv0: record.restInv0,
+                                               restInv1: record.restInv1,
+                                               restInv2: record.restInv2))
+        }
+        return SceneSkinnedMesh(vertices: vertices, triangles: mesh.triangles,
+                                bodyIDs: bodyIDs)
+    }
+
+    struct SkinBindPick {
+        var record: Int
+        var weights: SIMD4<Float>
+    }
+
+    private static func bindVisualMeshCPU(_ mesh: SurfaceMesh,
+                                          index: TetBindIndex) -> [SkinBindPick] {
+        var picks: [SkinBindPick] = []
+        picks.reserveCapacity(mesh.vertices.count)
+        for p in mesh.vertices {
+            var best: (record: Int, w: SIMD4<Float>, inside: Bool,
                        dist2: Float, outside: Float)?
-            let candidates = index.candidates(near: p, maxRing: 3)
-            let search = candidates.isEmpty ? index.records.indices.map { $0 } : candidates
+            var candidates = index.candidates(near: p, maxRing: 3)
+            var ring = 6
+            while candidates.isEmpty && ring <= 12 {
+                candidates = index.candidates(near: p, maxRing: ring)
+                ring *= 2
+            }
+            let search: [Int] = candidates.isEmpty
+                ? Array(index.records.indices) : candidates
             for ti in search {
                 let record = index.records[ti]
                 let w = record.barycentric(p)
@@ -777,27 +823,14 @@ extension Demos {
                     || (inside == best!.inside && d2 < best!.dist2)
                     || (inside == best!.inside && d2 == best!.dist2
                         && outside < best!.outside) {
-                    best = (record, w, inside, d2, outside)
+                    best = (ti, w, inside, d2, outside)
                 }
             }
-            if let best {
-                vertices.append(SceneSkinnedVertex(ids: best.record.ids,
-                                                   weights: best.w,
-                                                   restNormal: mesh.normals[vi],
-                                                   restInv0: best.record.restInv0,
-                                                   restInv1: best.record.restInv1,
-                                                   restInv2: best.record.restInv2))
-            } else if let first = index.records.first {
-                vertices.append(SceneSkinnedVertex(ids: first.ids,
-                                                   weights: SIMD4(0.25, 0.25, 0.25, 0.25),
-                                                   restNormal: mesh.normals[vi],
-                                                   restInv0: first.restInv0,
-                                                   restInv1: first.restInv1,
-                                                   restInv2: first.restInv2))
-            }
+            picks.append(SkinBindPick(
+                record: best?.record ?? 0,
+                weights: best?.w ?? SIMD4(0.25, 0.25, 0.25, 0.25)))
         }
-        return SceneSkinnedMesh(vertices: vertices, triangles: mesh.triangles,
-                                bodyIDs: bodyIDs)
+        return picks
     }
 
     private static func loadDefaultSkinMeshWithKey(meshPath: String?) -> (SurfaceMesh, String) {

--- a/Sources/GPUSimDemos/SoftMeshSkinning+Demos.swift
+++ b/Sources/GPUSimDemos/SoftMeshSkinning+Demos.swift
@@ -765,7 +765,7 @@ extension Demos {
         let index = TetBindIndex(tets: tetRange.map { scene.tets[$0] },
                                  scene: scene)
         guard !index.records.isEmpty else {
-            return SceneSkinnedMesh(vertices: [], triangles: mesh.triangles,
+            return SceneSkinnedMesh(vertices: [], triangles: [],
                                     bodyIDs: bodyIDs)
         }
         // Binding is a per-vertex nearest-tet search over a hash grid: it is

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -2896,6 +2896,8 @@ public final class GPUSolver {
         // The default heuristic often lands below the rigid margin as well,
         // so gating on the two values alone would widen the retry for
         // ordinary cloth and Planar-DAT scenes.
+        params.tetCompactionOnset = max(0, min(1, settings.tetCompactionOnset))
+        params.tetCompactionGain = max(0, settings.tetCompactionGain)
         params.deformablePortalRetryCap =
             settings.deformableCollisionMargin.map {
                 $0 < settings.collisionMargin

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -169,6 +169,7 @@ public final class GPUSolver {
     var tets: MTLBuffer
     var hashedIdx, globalIdx, hashedRigidIdx: MTLBuffer
     var cellCount, cellStart, cellBodies, cellRigid: MTLBuffer
+    var cellBodiesSorted: MTLBuffer
     var bodyCellSlot: MTLBuffer
     public let usesRigidColliderHierarchy: Bool
     public let rigidBroadphaseProxyCount: Int
@@ -284,6 +285,7 @@ public final class GPUSolver {
 
     // Adjacency + coloring
     var degrees, adjStart, adjCursor, adjList, adjNeighbor: MTLBuffer
+    var adjListSorted, adjSlotBody: MTLBuffer
     var colorsA, colorsB, bodySlot, colorStart, colorList: MTLBuffer
     var changedFlag: MTLBuffer
 
@@ -324,6 +326,11 @@ public final class GPUSolver {
         "bp_finalize_deterministic_pairs",
         "bp_scatter",
         "bp_sort_cells",
+        "bp_rank_cells",
+        "primal_particles_split_tail",
+        "primal_rigid_split_tail",
+        "primal_particles_split_torsion_tail",
+        "adj_rank",
         "build_instances",
         "color_count",
         "color_iterate",
@@ -1527,6 +1534,8 @@ public final class GPUSolver {
         cellStart = try makeBuf(gridHashSize * 4, "cellStart")
         cellBodies = try makeBuf(max(1, broadphaseItemCount) * 4,
                                  "cellBodies")
+        cellBodiesSorted = try makeBuf(max(1, broadphaseItemCount) * 4,
+                                       "cellBodiesSorted")
         bodyCellSlot = try makeBuf(max(1, broadphaseItemCount) * 8,
                                    "bodyCellSlot")
         pairCount = try makeBuf(max(maxPairs, broadphaseItemCount) * 4,
@@ -1613,6 +1622,8 @@ public final class GPUSolver {
         let adjacencyCapacity = 2 * (numJoints + numSprings + maxPairs)
             + 4 * numTets + 4 * maxSoft + 3 * numTris + 4 * maxEdges
         adjList = try makeBuf(adjacencyCapacity * 4, "adjList")
+        adjListSorted = try makeBuf(adjacencyCapacity * 4, "adjListSorted")
+        adjSlotBody = try makeBuf(adjacencyCapacity * 4, "adjSlotBody")
         let compactNeighborCapacity =
             ((numTris == 0 && numTets == 0) || deterministicColoring)
             && numBodies > Self.orderedColoringBodyLimit
@@ -3457,13 +3468,71 @@ public final class GPUSolver {
         }
     }
 
+    /// Compute dispatches encoded by the most recent frame. Small scenes are
+    /// launch-bound, so this is the number to watch when a frame's GPU time
+    /// does not track its arithmetic.
+    public private(set) var dispatchesLastFrame = 0
+    /// V-T and E-E emission drop every candidate inside one solid (the
+    /// `sameSolid_` gate in the kernels), so a scene whose surface elements
+    /// all belong to a single solid without cloth vertices never emits a
+    /// surface contact. Skipping the element grid and both emitters there is
+    /// exact. Rigid-vs-triangle emission is independent and still runs.
+    private lazy var surfaceEmissionNeeded: Bool = {
+        guard numTris > 0 else { return false }
+        let groups = clothGroupBuf.contents()
+            .bindMemory(to: UInt32.self, capacity: numBodies)
+        let cloth = clothVertFlag.contents()
+            .bindMemory(to: UInt32.self, capacity: numBodies)
+        let tris = trisBuf.contents()
+            .bindMemory(to: SIMD4<UInt32>.self, capacity: numTris)
+        let particles = particleIdxBuf.contents()
+            .bindMemory(to: UInt32.self, capacity: max(1, numParticles))
+        var solidGroups = Set<UInt32>()
+        func touches(_ v: Int) -> Bool {
+            if groups[v] == 0 || cloth[v] != 0 { return true }
+            solidGroups.insert(groups[v])
+            return false
+        }
+        for i in 0..<numParticles where touches(Int(particles[i])) {
+            return true
+        }
+        for t in 0..<numTris {
+            let ids = tris[t]
+            if touches(Int(ids.x)) || touches(Int(ids.y))
+                || touches(Int(ids.z)) { return true }
+        }
+        return solidGroups.count > 1
+    }()
+    /// Broadphase sizing of the current scene, for profiling output.
+    public var debugSceneCounts: [String: Int] {
+        ["hashed": Int(params.numHashed), "globals": Int(params.numGlobals),
+         "hashedRigid": Int(params.numHashedRigid), "tris": numTris,
+         "particles": numParticles, "gridHashSize": gridHashSize,
+         "rigidProxies": rigidBroadphaseProxyCount, "maxPairs": maxPairs,
+         "bodies": numBodies,
+         "cellSizeMicrons": Int(params.cellSize * 1e6),
+         "elemCellSizeMicrons": Int(params.elemCellSize * 1e6),
+         "elemHashSize": Int(params.elemHashSize)]
+    }
+    private var dispatchesThisFrame = 0
+    /// Per-kernel tally of the most recent frame's dispatches; raw
+    /// dispatchThreadgroups calls (the solve loop) are tallied as "raw".
+    public private(set) var dispatchNamesLastFrame: [String: Int] = [:]
+    private var dispatchNamesThisFrame: [String: Int] = [:]
+    private func noteDispatch(_ name: String) {
+        dispatchesThisFrame += 1
+        dispatchNamesThisFrame[name, default: 0] += 1
+    }
+
     private func dispatch1D(_ enc: MTLComputeCommandEncoder, _ name: String, _ count: Int,
                             _ setup: (MTLComputeCommandEncoder) -> Void) {
         guard count > 0 else { return }
+        noteDispatch(name)
         let p = ps(name)
         enc.setComputePipelineState(p)
         setup(enc)
         let tg = min(p.maxTotalThreadsPerThreadgroup, 256)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: (count + tg - 1) / tg, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: tg, height: 1, depth: 1))
     }
@@ -3471,9 +3540,11 @@ public final class GPUSolver {
     private func dispatchIndirect(_ enc: MTLComputeCommandEncoder, _ name: String,
                                   argsOffset: Int,
                                   _ setup: (MTLComputeCommandEncoder) -> Void) {
+        noteDispatch(name)
         let p = ps(name)
         enc.setComputePipelineState(p)
         setup(enc)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(indirectBuffer: dispatchArgs,
                                  indirectBufferOffset: argsOffset * 4,
                                  threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
@@ -3490,6 +3561,7 @@ public final class GPUSolver {
         enc.setBuffer(output, offset: 0, index: 1)
         enc.setBuffer(scanBlockSums, offset: 0, index: 2)
         enc.setBytes(&c, length: 4, index: 3)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: blocks, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
 
@@ -3499,6 +3571,7 @@ public final class GPUSolver {
         enc.setBuffer(scanBlockSums, offset: 0, index: 0)
         enc.setBytes(&nb, length: 4, index: 1)
         enc.setBuffer(scanTotal, offset: 0, index: 2)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
 
@@ -3526,6 +3599,9 @@ public final class GPUSolver {
         let counterSnapshot: MTLBuffer
         let frame: Int
         let usesDynamicColoring: Bool
+        /// First colour handed to the colour tail (AVBD_MAX_COLORS when
+        /// the per-colour loop covered the whole palette).
+        let colorBound: Int
         let softCapacity: Int
         let planarDATCapacity: Int
     }
@@ -3553,10 +3629,29 @@ public final class GPUSolver {
     var planarDATBodyIncidenceForTesting = false
     var planarDATPassObserverForTesting: ((PlanarDATPassSite) -> Void)?
     var persistentSolveForTesting = false
+    /// Colours dispatched per iteration beyond the last known palette size
+    /// before the colour tail takes over. Palettes grow by a few colours
+    /// when a contact cluster forms; eight keeps the tail idle in practice.
+    static let colorBoundMargin = 8
+    /// Overrides the margin (may be negative) so tests can force every
+    /// colour through the tail and compare against the dispatched loop.
+    var colorBoundMarginForTesting: Int?
+    /// Routes the broadphase bucket sort and the adjacency sort through the
+    /// original serial insertion-sort kernels so tests can show the
+    /// parallel rank sorts reproduce them exactly.
+    var legacySerialSortsForTesting = false
+    /// Runs the element grid and the V-T/E-E emitters even when
+    /// `surfaceEmissionNeeded` proves they cannot emit, for the same purpose.
+    var forceSurfaceEmissionForTesting = false
+    /// Colours solved by the tail dispatch in the most recently retired
+    /// frame (0 when the bounded loop covered the palette).
+    public private(set) var lastColorTailColors = 0
     enum SolveDispatchForTesting: Equatable {
         case primal(torsion: Bool)
         case dual(torsion: Bool)
         case persistent(torsion: Bool)
+        /// Single-threadgroup solve of the colours beyond the bounded loop.
+        case primalTail
     }
     var solveDispatchObserverForTesting: ((SolveDispatchForTesting) -> Void)?
     var convexQueryFailureForTesting = false
@@ -3651,6 +3746,7 @@ public final class GPUSolver {
         enc.setBuffer(out, offset: 0, index: 3)
         var r32 = UInt32(res)
         enc.setBytes(&r32, length: 4, index: 4)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: (res + 7) / 8, height: (res + 7) / 8,
                                          depth: numEnvs),
                                  threadsPerThreadgroup: MTLSize(width: 8, height: 8, depth: 1))
@@ -4447,6 +4543,7 @@ public final class GPUSolver {
             }
             lastColorCounts = counts
             lastMaxColorUsed = maxUsed
+            lastColorTailColors = max(0, maxUsed + 1 - submission.colorBound)
         }
         statsLock.unlock()
 
@@ -4763,7 +4860,7 @@ public final class GPUSolver {
         let d = MTLCounterSampleBufferDescriptor()
         d.counterSet = set
         d.storageMode = .shared
-        d.sampleCount = 128
+        d.sampleCount = 512
         counterBuf = try? device.makeCounterSampleBuffer(descriptor: d)
         return counterBuf
     }
@@ -4851,7 +4948,7 @@ public final class GPUSolver {
         stageNames = []
         func makeEncoder(_ name: String) -> MTLComputeCommandEncoder? {
             if deniedEncoderStageForTesting == name { return nil }
-            guard let sampleBuf, stageNames.count < 63 else {
+            guard let sampleBuf, stageNames.count < 255 else {
                 let e = cmd1.makeComputeCommandEncoder()
                 e?.label = name
                 return e
@@ -4980,6 +5077,7 @@ public final class GPUSolver {
                 encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                                  index: 15)
                 encoder.setBuffer(self.edgesBuf, offset: 0, index: 19)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     MTLSize(width: numParticles, height: 1, depth: 1),
                     threadsPerThreadgroup: MTLSize(width: 64, height: 1,
@@ -5006,6 +5104,7 @@ public final class GPUSolver {
                 encoder.setBuffer(self.counters, offset: 0, index: 14)
                 encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                                  index: 15)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     MTLSize(width: Int(P.numEdges), height: 1, depth: 1),
                     threadsPerThreadgroup: MTLSize(width: 64, height: 1,
@@ -5060,6 +5159,7 @@ public final class GPUSolver {
             // these exact step-start coordinates rather than double-counting
             // predictor displacement.
             encoder.setBuffer(referencePositions, offset: 0, index: 16)
+            noteDispatch("raw")
             encoder.dispatchThreadgroups(
                 indirectBuffer: planarDATArgsBuf,
                 indirectBufferOffset: 0,
@@ -5081,6 +5181,7 @@ public final class GPUSolver {
             encoder.setBuffer(edgesBuf, offset: 0, index: 4)
             encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                              index: 5)
+            noteDispatch("raw")
             encoder.dispatchThreadgroups(
                 indirectBuffer: planarDATArgsBuf,
                 indirectBufferOffset: 0,
@@ -5102,6 +5203,7 @@ public final class GPUSolver {
             encoder.setBuffer(edgesBuf, offset: 0, index: 5)
             encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                              index: 6)
+            noteDispatch("raw")
             encoder.dispatchThreadgroups(
                 indirectBuffer: planarDATArgsBuf,
                 indirectBufferOffset: 0,
@@ -5218,6 +5320,7 @@ public final class GPUSolver {
                     encoder.setBuffer(self.planarDATBodyPairsBuf, offset: 0,
                                       index: 14)
                     let threads = self.lastColorCounts[activeColor] * 8
+                    noteDispatch("raw")
                     encoder.dispatchThreadgroups(
                         MTLSize(width: (threads + 63) / 64,
                                 height: 1, depth: 1),
@@ -5226,6 +5329,7 @@ public final class GPUSolver {
                 } else {
                     encoder.setBuffer(colorsA, offset: 0, index: 9)
                     encoder.setBytes(&color, length: 4, index: 10)
+                    noteDispatch("raw")
                     encoder.dispatchThreadgroups(
                         indirectBuffer: planarDATArgsBuf,
                         indirectBufferOffset: 0,
@@ -5245,6 +5349,7 @@ public final class GPUSolver {
                                  length: MemoryLayout<SimParamsGPU>.stride,
                                  index: 8)
                 encoder.setBytes(&color, length: 4, index: 9)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     indirectBuffer: self.colorArgs,
                     indirectBufferOffset: activeColor * 12,
@@ -5254,6 +5359,7 @@ public final class GPUSolver {
                 encoder.setBuffer(colorsA, offset: 0, index: 9)
                 var fullPass = UInt32.max
                 encoder.setBytes(&fullPass, length: 4, index: 10)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     indirectBuffer: planarDATArgsBuf,
                     indirectBufferOffset: 0,
@@ -5312,6 +5418,7 @@ public final class GPUSolver {
         let broadphasePairOutput = usesRigidColliderHierarchy
             ? broadphaseProxyPairs : pairs
         if profiling { try stage("bp-count") }
+        if profiling { try stage("bp-count/bp_count") }
         dispatch1D(enc, "bp_count", Int(P.numHashed)) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.hashedIdx, offset: 0, index: 1)
@@ -5326,8 +5433,10 @@ public final class GPUSolver {
             e.setBuffer(bpGroup, offset: 0, index: 10)
         }
         if profiling { try stage("bp-scan") }
+        if profiling { try stage("bp-scan/scan") }
         encodeScan(enc, input: cellCount, output: cellStart, count: gridHashSize)
         if profiling { try stage("bp-scatter") }
+        if profiling { try stage("bp-scatter/bp_scatter") }
         dispatch1D(enc, "bp_scatter", Int(P.numHashed)) { e in
             e.setBuffer(self.hashedIdx, offset: 0, index: 0)
             e.setBuffer(self.bodyCellSlot, offset: 0, index: 1)
@@ -5335,14 +5444,31 @@ public final class GPUSolver {
             e.setBuffer(self.cellBodies, offset: 0, index: 3)
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
         }
-        var hashSize32 = UInt32(gridHashSize)
-        dispatch1D(enc, "bp_sort_cells", gridHashSize) { e in
-            e.setBuffer(self.cellStart, offset: 0, index: 0)
-            e.setBuffer(self.cellCount, offset: 0, index: 1)
-            e.setBuffer(self.cellBodies, offset: 0, index: 2)
-            e.setBytes(&hashSize32, length: 4, index: 3)
+        if legacySerialSortsForTesting {
+            var hashSize32 = UInt32(gridHashSize)
+            dispatch1D(enc, "bp_sort_cells", gridHashSize) { e in
+                e.setBuffer(self.cellStart, offset: 0, index: 0)
+                e.setBuffer(self.cellCount, offset: 0, index: 1)
+                e.setBuffer(self.cellBodies, offset: 0, index: 2)
+                e.setBytes(&hashSize32, length: 4, index: 3)
+            }
+        } else {
+        if profiling { try stage("bp-scatter/bp_rank_cells") }
+        dispatch1D(enc, "bp_rank_cells", Int(P.numHashed)) { e in
+            e.setBuffer(self.hashedIdx, offset: 0, index: 0)
+            e.setBuffer(self.bodyCellSlot, offset: 0, index: 1)
+            e.setBuffer(self.cellStart, offset: 0, index: 2)
+            e.setBuffer(self.cellCount, offset: 0, index: 3)
+            e.setBuffer(self.cellBodies, offset: 0, index: 4)
+            e.setBuffer(self.cellBodiesSorted, offset: 0, index: 5)
+            e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 6)
+        }
+        // Every later reader binds `cellBodies`; the scatter target and the
+        // sorted copy alternate roles frame by frame.
+        swap(&cellBodies, &cellBodiesSorted)
         }
         if numTris > 0 && P.numHashedRigid > 8 {
+            if profiling { try stage("bp-scatter/rt_pack_spatial_index") }
             dispatch1D(enc, "rt_pack_spatial_index",
                        max(gridHashSize, Int(P.numHashed))) { e in
                 e.setBuffer(self.cellStart, offset: 0, index: 0)
@@ -5356,6 +5482,7 @@ public final class GPUSolver {
         if profiling { try stage("bp-pairs") }
         let pairProducerCount = Int(P.numHashed + P.numGlobals)
         if pairProducerCount > 0 {
+            if profiling { try stage("bp-pairs/bp_count_pairs_deterministic") }
             dispatch1D(enc, "bp_count_pairs_deterministic", pairProducerCount) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(bpShape, offset: 0, index: 1)
@@ -5378,8 +5505,10 @@ public final class GPUSolver {
                 e.setBuffer(bpSharedCollision, offset: 0, index: 18)
                 e.setBuffer(bpShapeType, offset: 0, index: 19)
             }
+            if profiling { try stage("bp-pairs/scan") }
             encodeScan(enc, input: pairCount, output: pairStart,
                        count: pairProducerCount)
+            if profiling { try stage("bp-pairs/bp_emit_pairs_deterministic") }
             dispatch1D(enc, "bp_emit_pairs_deterministic", pairProducerCount) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(bpShape, offset: 0, index: 1)
@@ -5403,6 +5532,7 @@ public final class GPUSolver {
                 e.setBuffer(bpShapeType, offset: 0, index: 19)
             }
         }
+        if profiling { try stage("bp-pairs/bp_finalize_deterministic_pairs") }
         dispatch1D(enc, "bp_finalize_deterministic_pairs", 1) { e in
             e.setBuffer(self.pairCount, offset: 0, index: 0)
             e.setBuffer(self.pairStart, offset: 0, index: 1)
@@ -5411,6 +5541,7 @@ public final class GPUSolver {
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
         }
         if usesRigidColliderHierarchy {
+            if profiling { try stage("bp-pairs/bp_count_hierarchy_pairs") }
             dispatch1D(enc, "bp_count_hierarchy_pairs", maxPairs) { e in
                 e.setBuffer(self.broadphaseProxyPairs, offset: 0, index: 0)
                 e.setBuffer(self.counters, offset: 0, index: 1)
@@ -5428,8 +5559,10 @@ public final class GPUSolver {
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                            index: 13)
             }
+            if profiling { try stage("bp-pairs/scan") }
             encodeScan(enc, input: pairCount, output: pairStart,
                        count: maxPairs)
+            if profiling { try stage("bp-pairs/bp_emit_hierarchy_pairs") }
             dispatch1D(enc, "bp_emit_hierarchy_pairs", maxPairs) { e in
                 e.setBuffer(self.broadphaseProxyPairs, offset: 0, index: 0)
                 e.setBuffer(self.counters, offset: 0, index: 1)
@@ -5447,6 +5580,7 @@ public final class GPUSolver {
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                            index: 13)
             }
+            if profiling { try stage("bp-pairs/bp_finalize_hierarchy_pairs") }
             dispatch1D(enc, "bp_finalize_hierarchy_pairs", 1) { e in
                 e.setBuffer(self.pairCount, offset: 0, index: 0)
                 e.setBuffer(self.pairStart, offset: 0, index: 1)
@@ -5539,6 +5673,7 @@ public final class GPUSolver {
             }
         }
         if convexQueryFailureForTesting {
+            if profiling { try stage("narrowphase/convex_query_fail_for_testing") }
             dispatch1D(enc, "convex_query_fail_for_testing", 1) { e in
                 e.setBuffer(self.counters, offset: 0, index: 0)
                 e.setBuffer(self.colliderHullRange, offset: 0, index: 1)
@@ -5570,11 +5705,13 @@ public final class GPUSolver {
 
         try stage("persistence-map")
         // Rebuild persistence map from THIS frame's manifolds (for next frame)
+        if profiling { try stage("persistence-map/pm_clear") }
         dispatch1D(enc, "pm_clear", mapCapacity) { e in
             e.setBuffer(self.mapKeyA, offset: 0, index: 0)
             var cap = UInt32(self.mapCapacity)
             e.setBytes(&cap, length: 4, index: 1)
         }
+        if profiling { try stage("persistence-map/pm_insert") }
         dispatchIndirect(enc, "pm_insert", argsOffset: 0) { e in
             e.setBuffer(self.manifolds, offset: 0, index: 0)
             e.setBuffer(self.mapKeyA, offset: 0, index: 1)
@@ -5589,11 +5726,16 @@ public final class GPUSolver {
             // records remain on their existing start-pose path. The accepted
             // Planar stream is emitted after predictor acceptance below.
         if numTris > 0 {
-            if !isPlanarDAT {
+            if !isPlanarDAT, !surfaceEmissionNeeded,
+               !forceSurfaceEmissionForTesting {
+                // Single solid, no cloth: the emitters would drop every
+                // candidate (see surfaceEmissionNeeded). Exact skip.
+            } else if !isPlanarDAT {
             try stage("el-bin")
             encodeElementGrid(enc, clearFirst: false)
             try stage("vt-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_VT"] == nil {
+            if profiling { try stage("vt-emit/vt_emit") }
             dispatch1D(enc, "vt_emit", numParticles) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(self.shape, offset: 0, index: 1)
@@ -5666,6 +5808,7 @@ public final class GPUSolver {
             }
             try stage("rt-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_RT"] == nil {
+            if profiling { try stage("rt-emit/rt_emit") }
             dispatch1D(enc, "rt_emit", numTris) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(self.posAng, offset: 0, index: 1)
@@ -5790,10 +5933,12 @@ public final class GPUSolver {
         try stage("adjacency")
         // Adjacency
         var nb32 = UInt32(numBodies)
+        if profiling { try stage("adjacency/adj_clear_degrees") }
         dispatch1D(enc, "adj_clear_degrees", numBodies) { e in
             e.setBuffer(self.degrees, offset: 0, index: 0)
             e.setBytes(&nb32, length: 4, index: 1)
         }
+        if profiling { try stage("adjacency/adj_count") }
         dispatchIndirect(enc, "adj_count", argsOffset: 3) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.joints, offset: 0, index: 1)
@@ -5807,12 +5952,15 @@ public final class GPUSolver {
             e.setBuffer(self.membranes, offset: 0, index: 9)
             e.setBuffer(self.bends, offset: 0, index: 10)
         }
+        if profiling { try stage("adjacency/scan") }
         encodeScan(enc, input: degrees, output: adjStart, count: numBodies)
+        if profiling { try stage("adjacency/adj_copy_cursor") }
         dispatch1D(enc, "adj_copy_cursor", numBodies) { e in
             e.setBuffer(self.adjStart, offset: 0, index: 0)
             e.setBuffer(self.adjCursor, offset: 0, index: 1)
             e.setBytes(&nb32, length: 4, index: 2)
         }
+        if profiling { try stage("adjacency/adj_scatter") }
         dispatchIndirect(enc, "adj_scatter", argsOffset: 3) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.joints, offset: 0, index: 1)
@@ -5826,16 +5974,33 @@ public final class GPUSolver {
             e.setBuffer(self.softContacts, offset: 0, index: 9)
             e.setBuffer(self.membranes, offset: 0, index: 10)
             e.setBuffer(self.bends, offset: 0, index: 11)
+            e.setBuffer(self.adjSlotBody, offset: 0, index: 12)
         }
-        dispatch1D(enc, "adj_sort", numBodies) { e in
-            e.setBuffer(self.adjStart, offset: 0, index: 0)
-            e.setBuffer(self.degrees, offset: 0, index: 1)
-            e.setBuffer(self.adjList, offset: 0, index: 2)
-            e.setBytes(&nb32, length: 4, index: 3)
+        if legacySerialSortsForTesting {
+            dispatch1D(enc, "adj_sort", numBodies) { e in
+                e.setBuffer(self.adjStart, offset: 0, index: 0)
+                e.setBuffer(self.degrees, offset: 0, index: 1)
+                e.setBuffer(self.adjList, offset: 0, index: 2)
+                e.setBytes(&nb32, length: 4, index: 3)
+            }
+        } else {
+            if profiling { try stage("adjacency/adj_rank") }
+            dispatch1D(enc, "adj_rank", adjList.length / 4) { e in
+                e.setBuffer(self.adjStart, offset: 0, index: 0)
+                e.setBuffer(self.degrees, offset: 0, index: 1)
+                e.setBuffer(self.adjList, offset: 0, index: 2)
+                e.setBuffer(self.adjSlotBody, offset: 0, index: 3)
+                e.setBuffer(self.adjListSorted, offset: 0, index: 4)
+                e.setBytes(&nb32, length: 4, index: 5)
+            }
+            // Later readers bind `adjList`; scatter target and sorted copy
+            // alternate roles frame by frame.
+            swap(&adjList, &adjListSorted)
         }
         var neighborSlots32 = UInt32(neighborSlots)
         if usesDynamicColoring
             && numBodies > Self.orderedColoringBodyLimit {
+            if profiling { try stage("adjacency/adj_extract_neighbors") }
             dispatch1D(enc, "adj_extract_neighbors", numBodies) { e in
                 e.setBuffer(self.joints, offset: 0, index: 0)
                 e.setBuffer(self.springs, offset: 0, index: 1)
@@ -5880,6 +6045,7 @@ public final class GPUSolver {
             var src = colorsA, dst = colorsB
             let parallelColorPasses = 20
             for pass in 0..<parallelColorPasses {
+                if profiling { try stage("coloring/color_iterate") }
                 dispatch1D(enc, "color_iterate", numBodies) { e in
                     e.setBytes(&neighborSlots32, length: 4, index: 20)
                     e.setBuffer(self.posLin, offset: 0, index: 0)
@@ -5911,6 +6077,7 @@ public final class GPUSolver {
             // rare after settling and guarantees that validation never sees
             // an arbitrary iteration-limit artifact.
             var finalPass = UInt32(parallelColorPasses - 1)
+            if profiling { try stage("coloring/color_repair_greedy") }
             dispatch1D(enc, "color_repair_greedy", 1) { e in
                 e.setBytes(&neighborSlots32, length: 4, index: 20)
                 e.setBuffer(self.posLin, offset: 0, index: 0)
@@ -5931,6 +6098,7 @@ public final class GPUSolver {
                 e.setBytes(&finalPass, length: 4, index: 14)
                 e.setBuffer(self.adjNeighbor, offset: 0, index: 15)
             }
+            if profiling { try stage("coloring/color_validate") }
             dispatch1D(enc, "color_validate", numBodies) { e in
                 e.setBytes(&neighborSlots32, length: 4, index: 20)
                 e.setBuffer(self.posLin, offset: 0, index: 0)
@@ -5950,6 +6118,7 @@ public final class GPUSolver {
                 e.setBuffer(self.bends, offset: 0, index: 13)
                 e.setBuffer(self.adjNeighbor, offset: 0, index: 14)
             }
+            if profiling { try stage("coloring/color_count") }
             dispatch1D(enc, "color_count", numBodies) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(finalColors, offset: 0, index: 1)
@@ -5957,12 +6126,14 @@ public final class GPUSolver {
                 e.setBuffer(self.bodySlot, offset: 0, index: 3)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
             }
+            if profiling { try stage("coloring/color_scan") }
             dispatch1D(enc, "color_scan", AVBD_MAX_COLORS) { e in
                 e.setBuffer(self.counters, offset: 0, index: 0)
                 e.setBuffer(self.colorStart, offset: 0, index: 1)
                 e.setBuffer(self.colorArgs, offset: 0, index: 2)
                 e.setBytes(&primalThreadsPerBody, length: 4, index: 3)
             }
+            if profiling { try stage("coloring/color_scatter") }
             dispatch1D(enc, "color_scatter", numBodies) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(finalColors, offset: 0, index: 1)
@@ -5994,6 +6165,7 @@ public final class GPUSolver {
             }
         }
         try stage("solver-iterations")
+        var submittedColorBound = AVBD_MAX_COLORS
         let persistPSO = ps(hasTorsionalFriction
             ? "solve_persistent_torsion" : "solve_persistent")
         let multiPSO = ps("solve_persistent_multi")
@@ -6044,6 +6216,7 @@ public final class GPUSolver {
             enc.setBuffer(boundsBuf, offset: 0, index: 26)
             enc.setBuffer(ogcPrevBuf, offset: 0, index: 27)
             enc.setBuffer(counters, offset: 0, index: 28)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: Int(ntg), height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: tgW, height: 1, depth: 1))
         } else if persistentRequested && !isPlanarDAT
@@ -6085,6 +6258,7 @@ public final class GPUSolver {
                          ((max(numBodies, 64) + w - 1) / w) * w)
             solveDispatchObserverForTesting?(
                 .persistent(torsion: hasTorsionalFriction))
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: tg, height: 1, depth: 1))
         } else {
@@ -6092,8 +6266,27 @@ public final class GPUSolver {
         // buffer. Dispatch every representable color: zero-count indirect
         // calls are empty, while relying on an asynchronous CPU color bound
         // previously required a racy in-place "tail" solve.
-        let colorBound = usesDynamicColoring
-            ? AVBD_MAX_COLORS : staticUsedColors
+        // Dynamic palettes are sized on the GPU, so the CPU cannot know the
+        // exact colour count while encoding. Dispatching all 64 slots every
+        // iteration cost ~1000 empty dispatches per frame on a 16-colour
+        // scene. Instead bound the loop by the most recent readback plus a
+        // margin and let a single colour-tail dispatch solve any colours at
+        // or beyond the bound, exactly. The readback may be several frames
+        // stale under pipelining; that only moves work between the loop and
+        // the tail, never the result. Planar-DAT interleaves per-colour
+        // passes the tail does not replicate, and the scalar primal_solve
+        // has no tail, so both keep the full loop.
+        let usesColorTail = usesDynamicColoring && !isPlanarDAT && !noRSplit
+        let colorBound: Int
+        if usesColorTail {
+            let margin = colorBoundMarginForTesting ?? Self.colorBoundMargin
+            colorBound = max(0, min(AVBD_MAX_COLORS,
+                                    lastMaxColorUsed + 1 + margin))
+        } else {
+            colorBound = usesDynamicColoring
+                ? AVBD_MAX_COLORS : staticUsedColors
+        }
+        submittedColorBound = usesColorTail ? colorBound : AVBD_MAX_COLORS
         // Rigid scenes use the 8-lane cooperative split primal too: dense
         // piles average 12-27 manifolds/body and the one-thread-per-body
         // kernel was latency-bound walking them serially (boxpile x12
@@ -6200,10 +6393,12 @@ public final class GPUSolver {
                 solveDispatchObserverForTesting?(
                     .primal(torsion: hasTorsionalFriction))
                 if usesDynamicColoring {
+                    noteDispatch("raw")
                     enc.dispatchThreadgroups(indirectBuffer: colorArgs,
                                              indirectBufferOffset: c * 12,
                                              threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
                 } else {
+                    noteDispatch("raw")
                     enc.dispatchThreadgroups(
                         MTLSize(width: (splitSizes[c] + 63) / 64, height: 1, depth: 1),
                         threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
@@ -6241,6 +6436,23 @@ public final class GPUSolver {
                     enc.setBuffer(colorList, offset: 0, index: 13)
                     enc.setBuffer(colorStart, offset: 0, index: 14)
                 }
+            }
+            if usesColorTail && colorBound < AVBD_MAX_COLORS {
+                // Bindings 0-14 and 16-27 are still the primal's; only the
+                // pipeline and slot 15 (first tail colour) change.
+                let tailName = hasTorsionalFriction
+                    ? "primal_particles_split_torsion_tail"
+                    : (useWideRigidSplit ? "primal_rigid_split_tail"
+                                         : "primal_particles_split_tail")
+                var firstColor = UInt32(colorBound)
+                enc.setComputePipelineState(ps(tailName))
+                enc.setBytes(&firstColor, length: 4, index: 15)
+                solveDispatchObserverForTesting?(.primalTail)
+                noteDispatch(tailName)
+                enc.dispatchThreadgroups(
+                    MTLSize(width: 1, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 256, height: 1,
+                                                   depth: 1))
             }
             if profiling { try stage("solve-dual") }
             let dualName = hasTorsionalFriction
@@ -6297,6 +6509,7 @@ public final class GPUSolver {
                 enc.setBuffer(nbr2Start, offset: 0, index: 12)
                 enc.setBuffer(nbr2Count, offset: 0, index: 13)
                 enc.setBuffer(nbr2List, offset: 0, index: 14)
+                noteDispatch("raw")
                 enc.dispatchThreadgroups(indirectBuffer: ogcArgsBuf,
                                          indirectBufferOffset: 0,
                                          threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
@@ -6407,6 +6620,7 @@ public final class GPUSolver {
             commandBuffer: cmd1, counterSnapshot: counterSnapshot,
             frame: submittedFrame,
             usesDynamicColoring: usesDynamicColoring,
+            colorBound: submittedColorBound,
             softCapacity: Int(P.maxSoft),
             planarDATCapacity: Int(P.maxPlanarDATPairs))
         cmd1.commit()
@@ -6419,6 +6633,10 @@ public final class GPUSolver {
         }
         swap(&contactFeatures, &prevContactFeatures)
         if numTris > 0 { swap(&softContacts, &prevSoftContacts) }
+        dispatchesLastFrame = dispatchesThisFrame
+        dispatchesThisFrame = 0
+        dispatchNamesLastFrame = dispatchNamesThisFrame
+        dispatchNamesThisFrame = [:]
 
         if profiling {
             try retire(submission)
@@ -6695,6 +6913,7 @@ public final class GPUSolver {
                 appearanceOverrides ?? colliderRenderColor,
                 offset: 0, index: 13)
             enc.setBytes(&hasAppearanceOverrides, length: 4, index: 14)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (renderRigidBodyCount + 255) / 256,
                                              height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256,
@@ -6709,6 +6928,7 @@ public final class GPUSolver {
             enc.setBuffer(faceNormalsBuf, offset: 0, index: 2)
             var nt = UInt32(surfaceTriCount)
             enc.setBytes(&nt, length: 4, index: 3)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (surfaceTriCount + 255) / 256, height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
 
@@ -6728,6 +6948,7 @@ public final class GPUSolver {
             enc.setBuffer(clothVertFlag, offset: 0, index: 10)
             var cs = settings.clothRenderScale
             enc.setBytes(&cs, length: 4, index: 11)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (surfVertCount + 255) / 256, height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
         }
@@ -6739,6 +6960,7 @@ public final class GPUSolver {
             enc.setBuffer(skinVertexBuf, offset: 0, index: 2)
             var nv = UInt32(skinnedVertexCount)
             enc.setBytes(&nv, length: 4, index: 3)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (skinnedVertexCount + 255) / 256,
                                              height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -3441,6 +3441,9 @@ public final class GPUSolver {
         params.contactMaterialReserved = 0
         params.rigidLinearDamping = max(settings.rigidLinearDamping, 0)
         params.rigidAngularDamping = max(settings.rigidAngularDamping, 0)
+        params.tetCompactionOnset = max(
+            0, min(1, settings.tetCompactionOnset))
+        params.tetCompactionGain = max(0, settings.tetCompactionGain)
         let effectiveTruncationMode = effectiveSurfaceTruncationMode
         params.surfaceTruncationMode = numParticles > 0
             ? effectiveTruncationMode.rawValue : 0

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -5120,7 +5120,10 @@ public final class GPUSolver {
             // Re-index the emitted contacts by persistence key before the map
             // and the adjacency lists see them. The map buffers are free
             // scratch until softmap_clear below: keyA = bucket counts,
-            // keyB = bucket starts, val = scatter cursors.
+            // keyB = bucket starts, val = scatter cursors. Seven small
+            // dispatches per frame that only buy bitwise reproducibility, so
+            // they follow the deterministic setting.
+            if deterministicColoring {
             dispatch1D(encoder, "softmap_clear", self.softMapCapacity) { e in
                 e.setBuffer(self.softMapKeyA, offset: 0, index: 0)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
@@ -5166,6 +5169,7 @@ public final class GPUSolver {
                            index: 4)
             }
             swap(&softContacts, &softContactsScratch)
+            }
             dispatch1D(encoder, "softmap_clear", self.softMapCapacity) { e in
                 e.setBuffer(self.softMapKeyA, offset: 0, index: 0)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -5182,7 +5182,7 @@ public final class GPUSolver {
             // keyB = bucket starts, val = scatter cursors. Seven small
             // dispatches per frame that only buy bitwise reproducibility, so
             // they follow the deterministic setting.
-            if deterministicColoring {
+            if settings.deterministic {
             dispatch1D(encoder, "softmap_clear", self.softMapCapacity) { e in
                 e.setBuffer(self.softMapKeyA, offset: 0, index: 0)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,

--- a/Sources/PhysicsAVBD/GPU/GPUTypes.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUTypes.swift
@@ -81,6 +81,10 @@ public struct SimParamsGPU {
     /// scene explicitly asks for deformable accuracy tighter than its rigid
     /// margin.
     public var deformablePortalRetryCap: Float = 0
+    /// Tet compaction stiffening: onset volume ratio (0 = off) and gain in
+    /// units of lambda. See `SimSettings.tetCompactionOnset`.
+    public var tetCompactionOnset: Float = 0
+    public var tetCompactionGain: Float = 0
 }
 
 extension SimParamsGPU: Equatable {}

--- a/Sources/PhysicsAVBD/Shaders/00_common.metal
+++ b/Sources/PhysicsAVBD/Shaders/00_common.metal
@@ -287,6 +287,8 @@ struct SimParams {
     float surfaceContactCellSize; // legacy OGC velocity-inflation reference
     uint tetInversionPreventionEnabled; // independent signed-volume extension
     float deformablePortalRetryCap; // metres; 0 keeps the legacy 2*detect rigid/triangle retry cap
+    float tetCompactionOnset;   // volume ratio J below which tets stiffen; 0 = off
+    float tetCompactionGain;    // extra bulk stiffness below onset, in units of lambda
 };
 
 inline float combine_friction(float a, float b, uint mode) {

--- a/Sources/PhysicsAVBD/Shaders/20_broadphase.metal
+++ b/Sources/PhysicsAVBD/Shaders/20_broadphase.metal
@@ -154,6 +154,30 @@ kernel void bp_sort_cells(
     }
 }
 
+// Parallel form of the bucket sort above: every hashed item counts the
+// smaller ids in its bucket and scatters itself into the sorted copy. A
+// compact scene (one soft body inside a cell sized by its rigid neighbours)
+// puts hundreds of items into one bucket, where the serial insertion sort
+// ran ~0.6 ms per frame on a single thread. Same output, unique ids only.
+kernel void bp_rank_cells(
+    device const uint* hashedIdx    [[buffer(0)]],
+    device const uint2* bodyCellSlot [[buffer(1)]],
+    device const uint* cellStart    [[buffer(2)]],
+    device const uint* cellCount    [[buffer(3)]],
+    device const uint* cellBodies   [[buffer(4)]],   // scatter order
+    device uint* sortedBodies       [[buffer(5)]],
+    constant SimParams& P           [[buffer(6)]],
+    uint gid                        [[thread_position_in_grid]])
+{
+    if (gid >= P.numHashed) return;
+    uint value = hashedIdx[gid];
+    uint h = bodyCellSlot[gid].x;
+    uint s = cellStart[h], n = cellCount[h];
+    uint rank = 0;
+    for (uint k = 0; k < n; k++) rank += cellBodies[s + k] < value ? 1u : 0u;
+    sortedBodies[s + rank] = value;
+}
+
 // Binary search in sorted exclusion list of (a,b) pairs, a < b.
 inline bool pairExcluded(device const uint2* excl, uint count, uint a, uint b) {
     uint lo = 0, hi = count;

--- a/Sources/PhysicsAVBD/Shaders/40_solver.metal
+++ b/Sources/PhysicsAVBD/Shaders/40_solver.metal
@@ -1095,7 +1095,8 @@ inline void stampSpring(device const SpringGPU& sp, uint self,
 // dropping the indefinite second derivative of J.
 inline void stampTet(device const TetGPU& t, uint self,
                      device const float4* posLin,
-                     thread PrimalAccum& acc)
+                     thread PrimalAccum& acc,
+                     float compactionOnset, float compactionGain)
 {
     float3 x0 = posLin[t.ids.x].xyz;
     float3 x1 = posLin[t.ids.y].xyz;
@@ -1119,6 +1120,15 @@ inline void stampTet(device const TetGPU& t, uint self,
     float3 j2 = cross(f0, f1);
 
     float s2 = lamV * (J - alphaT);
+    // Compaction barrier: the stable Neo-Hookean volume term saturates as
+    // J -> 0, so a crushed tet offers no increasing resistance. Below the
+    // onset ratio add a quadratic bulk penalty of `gain * lambda`, the way
+    // stuffing compacts freely and then stiffens.
+    float compactionK = 0.0f;
+    if (compactionGain > 0.0f && J < compactionOnset) {
+        compactionK = compactionGain * lamV;
+        s2 += compactionK * (J - compactionOnset);
+    }
     // PK1 columns (scaled by volume via muV/lamV which premultiply vol)
     float3 p0 = muV * f0 + s2 * j0;
     float3 p1 = muV * f1 + s2 * j1;
@@ -1140,7 +1150,8 @@ inline void stampTet(device const TetGPU& t, uint self,
 
     acc.rhsLin += grad;
     acc.lhsLin = m3_add(acc.lhsLin, m3_diag(float3(muV * dot(w, w))));
-    acc.lhsLin = m3_add(acc.lhsLin, m3_scale(m3_outer(g, g), lamV));
+    acc.lhsLin = m3_add(acc.lhsLin,
+                        m3_scale(m3_outer(g, g), lamV + compactionK));
 }
 
 // Exact signed-J line limit for a colored tet update. Graph coloring gives
@@ -1803,7 +1814,8 @@ static inline void primal_one(
         } else if (kind == FK_SPRING) {
             stampSpring(springs[idx], body, posLin, posAng, acc, P.alpha);
         } else if (kind == FK_TET) {
-            stampTet(tets[idx], body, posLin, acc);
+            stampTet(tets[idx], body, posLin, acc,
+                     P.tetCompactionOnset, P.tetCompactionGain);
         } else if (kind == FK_SOFT) {
             stampSoft(soft[idx], body, posLin, posAng, initLin, initAng, P.alpha, acc);
         } else if (kind == FK_MEMBRANE) {
@@ -1920,7 +1932,8 @@ static inline void primal_one_torsion(
         } else if (kind == FK_SPRING) {
             stampSpring(springs[idx], body, posLin, posAng, acc, P.alpha);
         } else if (kind == FK_TET) {
-            stampTet(tets[idx], body, posLin, acc);
+            stampTet(tets[idx], body, posLin, acc,
+                     P.tetCompactionOnset, P.tetCompactionGain);
         } else if (kind == FK_SOFT) {
             stampSoft(soft[idx], body, posLin, posAng, initLin, initAng,
                       P.alpha, acc);
@@ -2121,7 +2134,8 @@ static inline void primal_split_impl(
         } else if (kind == FK_SPRING) {
             stampSpring(springs[idx], body, posLin, posAng, acc, P.alpha);
         } else if (kind == FK_TET) {
-            stampTet(tets[idx], body, posLin, acc);
+            stampTet(tets[idx], body, posLin, acc,
+                     P.tetCompactionOnset, P.tetCompactionGain);
         } else if (kind == FK_SOFT) {
             stampSoft(soft[idx], body, posLin, posAng, initLin, initAng, P.alpha, acc);
         } else if (kind == FK_MEMBRANE) {
@@ -2268,7 +2282,8 @@ kernel void primal_particles_split_torsion(
         } else if (kind == FK_SPRING) {
             stampSpring(springs[idx], body, posLin, posAng, acc, P.alpha);
         } else if (kind == FK_TET) {
-            stampTet(tets[idx], body, posLin, acc);
+            stampTet(tets[idx], body, posLin, acc,
+                     P.tetCompactionOnset, P.tetCompactionGain);
         } else if (kind == FK_SOFT) {
             stampSoft(soft[idx], body, posLin, posAng, initLin, initAng,
                       P.alpha, acc);

--- a/Sources/PhysicsAVBD/Shaders/40_solver.metal
+++ b/Sources/PhysicsAVBD/Shaders/40_solver.metal
@@ -1125,7 +1125,8 @@ inline void stampTet(device const TetGPU& t, uint self,
     // onset ratio add a quadratic bulk penalty of `gain * lambda`, the way
     // stuffing compacts freely and then stiffens.
     float compactionK = 0.0f;
-    if (compactionGain > 0.0f && J < compactionOnset) {
+    if (compactionOnset > 0.0f && compactionGain > 0.0f
+        && J < compactionOnset) {
         compactionK = compactionGain * lamV;
         s2 += compactionK * (J - compactionOnset);
     }

--- a/Sources/PhysicsAVBD/Shaders/40_solver.metal
+++ b/Sources/PhysicsAVBD/Shaders/40_solver.metal
@@ -131,6 +131,7 @@ kernel void adj_scatter(
     device const SoftContactGPU* soft [[buffer(9)]],
     device const MembraneGPU* membranes [[buffer(10)]],
     device const BendGPU* bends     [[buffer(11)]],
+    device uint* slotBody           [[buffer(12)]],   // owner of each slot, for adj_rank
     uint gid                        [[thread_position_in_grid]])
 {
     uint numPairs = atomic_load_explicit(&counters[CTR_PAIRS], memory_order_relaxed);
@@ -148,6 +149,7 @@ kernel void adj_scatter(
                 if (bodyDynamic(posLin, ids[k])) {
                     uint slot = atomic_fetch_add_explicit(&cursor[ids[k]], 1u, memory_order_relaxed);
                     adjList[slot] = entry;
+                    slotBody[slot] = ids[k];
                 }
             }
         } else {
@@ -158,6 +160,7 @@ kernel void adj_scatter(
                 if (bodyDynamic(posLin, ids[k])) {
                     uint slot = atomic_fetch_add_explicit(&cursor[ids[k]], 1u, memory_order_relaxed);
                     adjList[slot] = entry;
+                    slotBody[slot] = ids[k];
                 }
             }
         }
@@ -193,6 +196,7 @@ kernel void adj_scatter(
             if (bodyDynamic(posLin, v)) {
                 uint slot = atomic_fetch_add_explicit(&cursor[v], 1u, memory_order_relaxed);
                 adjList[slot] = entry;
+                slotBody[slot] = v;
             }
         }
         return;
@@ -205,6 +209,7 @@ kernel void adj_scatter(
             if (v != WORLD_BODY && bodyDynamic(posLin, v)) {
                 uint slot = atomic_fetch_add_explicit(&cursor[v], 1u, memory_order_relaxed);
                 adjList[slot] = entry;
+                slotBody[slot] = v;
             }
         }
         return;
@@ -212,10 +217,12 @@ kernel void adj_scatter(
     if (bodyDynamic(posLin, a)) {
         uint slot = atomic_fetch_add_explicit(&cursor[a], 1u, memory_order_relaxed);
         adjList[slot] = entry;
+        slotBody[slot] = a;
     }
     if (bodyDynamic(posLin, b)) {
         uint slot = atomic_fetch_add_explicit(&cursor[b], 1u, memory_order_relaxed);
         adjList[slot] = entry;
+        slotBody[slot] = b;
     }
 }
 
@@ -223,6 +230,29 @@ kernel void adj_scatter(
 // dependent summation order. Once pair/manifold indices are deterministic,
 // sorting each (typically short) CSR segment makes every primal accumulation
 // bitwise repeatable for a fixed input state.
+// Parallel form of adj_sort: one thread per filled slot ranks its entry
+// inside the owner's segment and writes the sorted copy. Entries are unique
+// per body (an element lists a body once), so ranks are a permutation.
+kernel void adj_rank(
+    device const uint* adjStart     [[buffer(0)]],
+    device const uint* adjCount     [[buffer(1)]],
+    device const uint* adjList      [[buffer(2)]],   // scatter order
+    device const uint* slotBody     [[buffer(3)]],
+    device uint* sortedList         [[buffer(4)]],
+    constant uint& numBodies        [[buffer(5)]],
+    uint gid                        [[thread_position_in_grid]])
+{
+    if (numBodies == 0) return;
+    uint total = adjStart[numBodies - 1] + adjCount[numBodies - 1];
+    if (gid >= total) return;
+    uint b = slotBody[gid];
+    uint s = adjStart[b], n = adjCount[b];
+    uint value = adjList[gid];
+    uint rank = 0;
+    for (uint k = 0; k < n; k++) rank += adjList[s + k] < value ? 1u : 0u;
+    sortedList[s + rank] = value;
+}
+
 kernel void adj_sort(
     device const uint* adjStart     [[buffer(0)]],
     device const uint* adjCount     [[buffer(1)]],
@@ -2072,8 +2102,8 @@ kernel void primal_solve_torsion(
 // the group reduces the system via simd_shuffle_xor, and lane 0 solves.
 // Per-body serial stamping (~20-30 scattered gathers) left contact-rich
 // dispatches latency-bound; cooperative stamping exposes those gathers.
-template <uint splitShift, uint splitWidth>
-static inline void primal_split_impl(
+template <uint splitWidth>
+static inline void primal_split_body_impl(
     device float4* posLin,
     device float4* posAng,
     device const float4* initLin,
@@ -2087,9 +2117,6 @@ static inline void primal_split_impl(
     device const uint* adjStart,
     device const uint* adjCount,
     device const uint* adjList,
-    device const uint* colorList,
-    device const uint* colorStart,
-    constant uint& colorIndex,
     constant SimParams& P,
     device const float4* shape,
     device const TetGPU* tets,
@@ -2102,14 +2129,8 @@ static inline void primal_split_impl(
     device const SolverManifoldGPU* solveManifolds,
     device const SolverContactGPU* solveContacts,
     constant uint& useCompactManifolds,
-    uint tid)
+    uint body, uint lane)
 {
-    uint s = colorStart[colorIndex];
-    uint e = colorStart[colorIndex + 1];
-    uint slot = tid >> splitShift;
-    uint lane = tid & (splitWidth - 1u);
-    if (s + slot >= e) return;       // uniform across the cooperative group
-    uint body = colorList[s + slot];
     // Rigids stamp cooperatively too: a box resting on high-res cloth
     // gathers THOUSANDS of contacts (rt corner-tri + particle np) in its
     // adjacency — serialized on one lane it gated the whole dispatch
@@ -2223,44 +2244,82 @@ static inline void primal_split_impl(
     if (rigid) posAng[body] = q_addw(posAng[body], dxAng);
 }
 
-// Fused torsion specialization of the cooperative primal. Its dispatch and
-// reduction topology exactly match `primal_particles_split`; the only added
-// work is one rank-1 angular stamp when a lane owns a manifold adjacency.
-kernel void primal_particles_split_torsion(
-    device float4* posLin           [[buffer(0)]],
-    device float4* posAng           [[buffer(1)]],
-    device const float4* initLin    [[buffer(2)]],
-    device const float4* initAng    [[buffer(3)]],
-    device const float4* inertLin   [[buffer(4)]],
-    device const float4* inertAng   [[buffer(5)]],
-    device const float4* props      [[buffer(6)]],
-    device const JointGPU* joints   [[buffer(7)]],
-    device const SpringGPU* springs [[buffer(8)]],
-    device const ManifoldGPU* manifolds [[buffer(9)]],
-    device const uint* adjStart     [[buffer(10)]],
-    device const uint* adjCount     [[buffer(11)]],
-    device const uint* adjList      [[buffer(12)]],
-    device const uint* colorList    [[buffer(13)]],
-    device const uint* colorStart   [[buffer(14)]],
-    constant uint& colorIndex       [[buffer(15)]],
-    constant SimParams& P           [[buffer(16)]],
-    device const float4* shape      [[buffer(17)]],
-    device const TetGPU* tets       [[buffer(18)]],
-    device const SoftContactGPU* soft [[buffer(19)]],
-    device const MembraneGPU* membranes [[buffer(20)]],
-    device const BendGPU* bends     [[buffer(21)]],
-    device const uint* boundsBits   [[buffer(22)]],
-    device const float4* ogcPrev    [[buffer(23)]],
-    device atomic_uint* ogcCounters [[buffer(24)]],
-    device const float4* torsionState [[buffer(25)]],
-    uint tid                        [[thread_position_in_grid]])
+template <uint splitShift, uint splitWidth>
+static inline void primal_split_impl(
+    device float4* posLin,
+    device float4* posAng,
+    device const float4* initLin,
+    device const float4* initAng,
+    device const float4* inertLin,
+    device const float4* inertAng,
+    device const float4* props,
+    device const JointGPU* joints,
+    device const SpringGPU* springs,
+    device const ManifoldGPU* manifolds,
+    device const uint* adjStart,
+    device const uint* adjCount,
+    device const uint* adjList,
+    device const uint* colorList,
+    device const uint* colorStart,
+    constant uint& colorIndex,
+    constant SimParams& P,
+    device const float4* shape,
+    device const TetGPU* tets,
+    device const SoftContactGPU* soft,
+    device const MembraneGPU* membranes,
+    device const BendGPU* bends,
+    device const uint* boundsBits,
+    device const float4* ogcPrev,
+    device atomic_uint* ogcCounters,
+    device const SolverManifoldGPU* solveManifolds,
+    device const SolverContactGPU* solveContacts,
+    constant uint& useCompactManifolds,
+    uint tid)
 {
     uint s = colorStart[colorIndex];
     uint e = colorStart[colorIndex + 1];
-    uint slot = tid >> 3;
-    uint lane = tid & 7u;
-    if (s + slot >= e) return;
-    uint body = colorList[s + slot];
+    uint slot = tid >> splitShift;
+    uint lane = tid & (splitWidth - 1u);
+    if (s + slot >= e) return;       // uniform across the cooperative group
+    primal_split_body_impl<splitWidth>(
+        posLin, posAng, initLin, initAng, inertLin, inertAng, props,
+        joints, springs, manifolds, adjStart, adjCount, adjList, P, shape,
+        tets, soft, membranes, bends, boundsBits, ogcPrev, ogcCounters,
+        solveManifolds, solveContacts, useCompactManifolds,
+        colorList[s + slot], lane);
+}
+
+// Fused torsion specialization of the cooperative primal. Its dispatch and
+// reduction topology exactly match `primal_particles_split`; the only added
+// work is one rank-1 angular stamp when a lane owns a manifold adjacency.
+// Body-level torsion primal shared by the per-colour dispatch and the
+// single-threadgroup colour tail (see primal_particles_split_torsion_tail).
+static inline void primal_split_torsion_body(
+    device float4* posLin,
+    device float4* posAng,
+    device const float4* initLin,
+    device const float4* initAng,
+    device const float4* inertLin,
+    device const float4* inertAng,
+    device const float4* props,
+    device const JointGPU* joints,
+    device const SpringGPU* springs,
+    device const ManifoldGPU* manifolds,
+    device const uint* adjStart,
+    device const uint* adjCount,
+    device const uint* adjList,
+    constant SimParams& P,
+    device const float4* shape,
+    device const TetGPU* tets,
+    device const SoftContactGPU* soft,
+    device const MembraneGPU* membranes,
+    device const BendGPU* bends,
+    device const uint* boundsBits,
+    device const float4* ogcPrev,
+    device atomic_uint* ogcCounters,
+    device const float4* torsionState,
+    uint body, uint lane)
+{
     bool rigid = shape[body].w >= 0.0f;
 
     PrimalAccum acc;
@@ -2370,6 +2429,104 @@ kernel void primal_particles_split_torsion(
     if (rigid) posAng[body] = q_addw(posAng[body], dxAng);
 }
 
+kernel void primal_particles_split_torsion(
+    device float4* posLin           [[buffer(0)]],
+    device float4* posAng           [[buffer(1)]],
+    device const float4* initLin    [[buffer(2)]],
+    device const float4* initAng    [[buffer(3)]],
+    device const float4* inertLin   [[buffer(4)]],
+    device const float4* inertAng   [[buffer(5)]],
+    device const float4* props      [[buffer(6)]],
+    device const JointGPU* joints   [[buffer(7)]],
+    device const SpringGPU* springs [[buffer(8)]],
+    device const ManifoldGPU* manifolds [[buffer(9)]],
+    device const uint* adjStart     [[buffer(10)]],
+    device const uint* adjCount     [[buffer(11)]],
+    device const uint* adjList      [[buffer(12)]],
+    device const uint* colorList    [[buffer(13)]],
+    device const uint* colorStart   [[buffer(14)]],
+    constant uint& colorIndex       [[buffer(15)]],
+    constant SimParams& P           [[buffer(16)]],
+    device const float4* shape      [[buffer(17)]],
+    device const TetGPU* tets       [[buffer(18)]],
+    device const SoftContactGPU* soft [[buffer(19)]],
+    device const MembraneGPU* membranes [[buffer(20)]],
+    device const BendGPU* bends     [[buffer(21)]],
+    device const uint* boundsBits   [[buffer(22)]],
+    device const float4* ogcPrev    [[buffer(23)]],
+    device atomic_uint* ogcCounters [[buffer(24)]],
+    device const float4* torsionState [[buffer(25)]],
+    uint tid                        [[thread_position_in_grid]])
+{
+    uint s = colorStart[colorIndex];
+    uint e = colorStart[colorIndex + 1];
+    uint slot = tid >> 3;
+    uint lane = tid & 7u;
+    if (s + slot >= e) return;
+    primal_split_torsion_body(
+        posLin, posAng, initLin, initAng, inertLin, inertAng, props,
+        joints, springs, manifolds, adjStart, adjCount, adjList, P, shape,
+        tets, soft, membranes, bends, boundsBits, ogcPrev, ogcCounters,
+        torsionState, colorList[s + slot], lane);
+}
+
+// Colour tail: the CPU bounds the per-colour dispatch loop by last frame's
+// palette size plus a margin (a stale readback under pipelining is fine,
+// the bound only affects speed). Colours at or beyond that bound are solved
+// here, exactly as the per-colour dispatches would: one threadgroup walks
+// the remaining colours in order, and inside a colour bodies are
+// independent, so waves of threadgroup-size / 8 bodies separated by a
+// device-memory barrier reproduce the dispatched result bit for bit.
+kernel void primal_particles_split_torsion_tail(
+    device float4* posLin           [[buffer(0)]],
+    device float4* posAng           [[buffer(1)]],
+    device const float4* initLin    [[buffer(2)]],
+    device const float4* initAng    [[buffer(3)]],
+    device const float4* inertLin   [[buffer(4)]],
+    device const float4* inertAng   [[buffer(5)]],
+    device const float4* props      [[buffer(6)]],
+    device const JointGPU* joints   [[buffer(7)]],
+    device const SpringGPU* springs [[buffer(8)]],
+    device const ManifoldGPU* manifolds [[buffer(9)]],
+    device const uint* adjStart     [[buffer(10)]],
+    device const uint* adjCount     [[buffer(11)]],
+    device const uint* adjList      [[buffer(12)]],
+    device const uint* colorList    [[buffer(13)]],
+    device const uint* colorStart   [[buffer(14)]],
+    constant uint& firstColor       [[buffer(15)]],
+    constant SimParams& P           [[buffer(16)]],
+    device const float4* shape      [[buffer(17)]],
+    device const TetGPU* tets       [[buffer(18)]],
+    device const SoftContactGPU* soft [[buffer(19)]],
+    device const MembraneGPU* membranes [[buffer(20)]],
+    device const BendGPU* bends     [[buffer(21)]],
+    device const uint* boundsBits   [[buffer(22)]],
+    device const float4* ogcPrev    [[buffer(23)]],
+    device atomic_uint* ogcCounters [[buffer(24)]],
+    device const float4* torsionState [[buffer(25)]],
+    uint ltid                       [[thread_index_in_threadgroup]],
+    uint tgSize                     [[threads_per_threadgroup]])
+{
+    uint used = colorStart[MAX_COLORS + 1];
+    uint slots = tgSize >> 3;
+    uint lane = ltid & 7u;
+    for (uint c = firstColor; c < used; c++) {
+        uint s = colorStart[c];
+        uint e = colorStart[c + 1];
+        for (uint base = s; base < e; base += slots) {
+            uint slot = base + (ltid >> 3);
+            if (slot < e) {
+                primal_split_torsion_body(
+                posLin, posAng, initLin, initAng, inertLin, inertAng, props,
+                joints, springs, manifolds, adjStart, adjCount, adjList, P, shape,
+                tets, soft, membranes, bends, boundsBits, ogcPrev, ogcCounters,
+                torsionState, colorList[slot], lane);
+            }
+            threadgroup_barrier(mem_flags::mem_device);
+        }
+    }
+}
+
 #define PRIMAL_SPLIT_KERNEL_ARGS \
     device float4* posLin [[buffer(0)]], \
     device float4* posAng [[buffer(1)]], \
@@ -2418,6 +2575,73 @@ kernel void primal_rigid_split(PRIMAL_SPLIT_KERNEL_ARGS)
 {
     CALL_PRIMAL_SPLIT(4u, 16u);
 }
+
+#define PRIMAL_SPLIT_TAIL_KERNEL_ARGS \
+    device float4* posLin [[buffer(0)]], \
+    device float4* posAng [[buffer(1)]], \
+    device const float4* initLin [[buffer(2)]], \
+    device const float4* initAng [[buffer(3)]], \
+    device const float4* inertLin [[buffer(4)]], \
+    device const float4* inertAng [[buffer(5)]], \
+    device const float4* props [[buffer(6)]], \
+    device const JointGPU* joints [[buffer(7)]], \
+    device const SpringGPU* springs [[buffer(8)]], \
+    device const ManifoldGPU* manifolds [[buffer(9)]], \
+    device const uint* adjStart [[buffer(10)]], \
+    device const uint* adjCount [[buffer(11)]], \
+    device const uint* adjList [[buffer(12)]], \
+    device const uint* colorList [[buffer(13)]], \
+    device const uint* colorStart [[buffer(14)]], \
+    constant uint& firstColor [[buffer(15)]], \
+    constant SimParams& P [[buffer(16)]], \
+    device const float4* shape [[buffer(17)]], \
+    device const TetGPU* tets [[buffer(18)]], \
+    device const SoftContactGPU* soft [[buffer(19)]], \
+    device const MembraneGPU* membranes [[buffer(20)]], \
+    device const BendGPU* bends [[buffer(21)]], \
+    device const uint* boundsBits [[buffer(22)]], \
+    device const float4* ogcPrev [[buffer(23)]], \
+    device atomic_uint* ogcCounters [[buffer(24)]], \
+    device const SolverManifoldGPU* solveManifolds [[buffer(25)]], \
+    device const SolverContactGPU* solveContacts [[buffer(26)]], \
+    constant uint& useCompactManifolds [[buffer(27)]], \
+    uint ltid [[thread_index_in_threadgroup]], \
+    uint tgSize [[threads_per_threadgroup]]
+
+// Colour tail for the lane-split kernels; see primal_particles_split_torsion_tail.
+#define PRIMAL_SPLIT_TAIL(SHIFT, WIDTH) \
+    uint used = colorStart[MAX_COLORS + 1]; \
+    uint slots = tgSize >> SHIFT; \
+    uint lane = ltid & (WIDTH - 1u); \
+    for (uint c = firstColor; c < used; c++) { \
+        uint s = colorStart[c]; \
+        uint e = colorStart[c + 1]; \
+        for (uint base = s; base < e; base += slots) { \
+            uint slot = base + (ltid >> SHIFT); \
+            if (slot < e) { \
+                primal_split_body_impl<WIDTH>( \
+                    posLin, posAng, initLin, initAng, inertLin, inertAng, \
+                    props, joints, springs, manifolds, adjStart, adjCount, \
+                    adjList, P, shape, tets, soft, membranes, bends, \
+                    boundsBits, ogcPrev, ogcCounters, solveManifolds, \
+                    solveContacts, useCompactManifolds, colorList[slot], \
+                    lane); \
+            } \
+            threadgroup_barrier(mem_flags::mem_device); \
+        } \
+    }
+
+kernel void primal_particles_split_tail(PRIMAL_SPLIT_TAIL_KERNEL_ARGS)
+{
+    PRIMAL_SPLIT_TAIL(3u, 8u);
+}
+
+kernel void primal_rigid_split_tail(PRIMAL_SPLIT_TAIL_KERNEL_ARGS)
+{
+    PRIMAL_SPLIT_TAIL(4u, 16u);
+}
+#undef PRIMAL_SPLIT_TAIL
+#undef PRIMAL_SPLIT_TAIL_KERNEL_ARGS
 
 #undef CALL_PRIMAL_SPLIT
 #undef PRIMAL_SPLIT_KERNEL_ARGS

--- a/Sources/SimCore/Scenes/Scene.swift
+++ b/Sources/SimCore/Scenes/Scene.swift
@@ -560,6 +560,15 @@ public struct SimSettings {
     /// ordered. Costs more colors (more primal dispatches per iteration) and
     /// a per-frame recoloring. Rigid-only scenes are reproducible either way.
     public var deterministic: Bool = false
+    /// Compaction stiffening for tetrahedral soft bodies. The stable
+    /// Neo-Hookean volume term is bounded as a tet is crushed flat, so a
+    /// low-modulus plush pinched by a torque-limited gripper collapses to a
+    /// sheet with no grip. Below volume ratio `tetCompactionOnset` (0 = off)
+    /// the bulk stiffness is raised by `tetCompactionGain` times lambda,
+    /// modelling stuffing that compacts and then stiffens sharply. Softness
+    /// in bending, shear and moderate compression is unchanged.
+    public var tetCompactionOnset: Float = 0
+    public var tetCompactionGain: Float = 0
     public var frictionCombineMode: FrictionCombineMode = .geometricMean
     public var alpha: Float = 0.99
     // 10000 matches the reference avbd-demo3d default (its in-code note

--- a/Sources/SimCore/Scenes/SurfaceMeshNormals.swift
+++ b/Sources/SimCore/Scenes/SurfaceMeshNormals.swift
@@ -9,7 +9,7 @@ extension SurfaceMesh {
     /// Equal face weighting prevents tessellation density from changing the
     /// apparent curvature: a large, irregular CAD triangle must not overpower
     /// several smaller neighbours that describe the same smooth surface.
-    func withCreaseNormals(
+    public func withCreaseNormals(
         maxSmoothAngleRadians: Float,
         weldTolerance: Float = 1e-4
     ) -> SurfaceMesh {
@@ -78,6 +78,33 @@ extension SurfaceMesh {
             vertices: outputVertices,
             normals: outputNormals,
             triangles: outputTriangles).withConsistentNormals()
+    }
+}
+
+extension SurfaceMesh {
+    /// Smooth vertex normals on the existing welded topology: each vertex
+    /// takes the normalized sum of its incident unit face normals. Unlike
+    /// `withCreaseNormals`, no corners are split, so an organic asset keeps
+    /// its vertex count for skinning and rendering.
+    public func withSmoothNormals() -> SurfaceMesh {
+        guard !vertices.isEmpty, !triangles.isEmpty else { return self }
+        var sums = [F3](repeating: .zero, count: vertices.count)
+        for triangle in triangles {
+            let a = vertices[triangle.0]
+            let b = vertices[triangle.1]
+            let c = vertices[triangle.2]
+            let normal = normalizedOrZero(cross(b - a, c - a))
+            sums[triangle.0] += normal
+            sums[triangle.1] += normal
+            sums[triangle.2] += normal
+        }
+        let smoothed = sums.enumerated().map { index, sum in
+            normalizedOrZero(sum, fallback: normals.indices.contains(index)
+                ? normals[index] : F3(0, 0, 1))
+        }
+        return SurfaceMesh(
+            vertices: vertices, normals: smoothed, triangles: triangles)
+            .withConsistentNormals()
     }
 }
 

--- a/Tests/PhysicsAVBDTests/GPUSolverTests.swift
+++ b/Tests/PhysicsAVBDTests/GPUSolverTests.swift
@@ -852,6 +852,131 @@ final class GPUSolverTests: XCTestCase {
     /// reproducible as rigid manifolds. Their emission is parallel, so the
     /// solver has to assign contact indices and element candidate order by
     /// content rather than by which thread won an atomic append.
+    /// The bounded colour loop plus the colour-tail dispatch must reproduce
+    /// the fully dispatched loop bit for bit: run one solver with a margin
+    /// that never engages the tail and one that pushes every colour into it.
+    private func assertBitwiseEqualStates(
+        _ a: GPUSolver, _ b: GPUSolver, bodies: [Int], _ label: String,
+        file: StaticString = #filePath, line: UInt = #line) {
+        let sa = a.bodyStates(bodies)
+        let sb = b.bodyStates(bodies)
+        var mismatches = 0
+        for i in sa.indices where sa[i].position.x.bitPattern
+            != sb[i].position.x.bitPattern
+            || sa[i].position.y.bitPattern != sb[i].position.y.bitPattern
+            || sa[i].position.z.bitPattern != sb[i].position.z.bitPattern
+            || sa[i].linearVelocity.x.bitPattern
+                != sb[i].linearVelocity.x.bitPattern
+            || sa[i].rotation.real.bitPattern
+                != sb[i].rotation.real.bitPattern {
+            mismatches += 1
+        }
+        XCTAssertEqual(mismatches, 0,
+            "\(label): \(mismatches) of \(bodies.count) bodies differ",
+            file: file, line: line)
+    }
+
+    /// The parallel rank sorts (bp_rank_cells, adj_rank) replace serial
+    /// per-bucket insertion sorts; the sorted streams must be identical, so
+    /// the trajectories must match bit for bit.
+    func testParallelRankSortsMatchSerialSorts() throws {
+        var cloth = Demos.cloth(res: 12, ball: true)
+        cloth.settings.deterministic = true
+        var pile = Demos.boxpile(count: 60)
+        pile.settings.deterministic = true
+        for (label, scene) in [("cloth", cloth), ("boxpile", pile)] {
+            let bodies = Array(0..<scene.bodies.count)
+            let parallel = try makeGPU(scene)
+            let serial = try makeGPU(scene)
+            serial.legacySerialSortsForTesting = true
+            for _ in 0..<120 {
+                parallel.step()
+                serial.step()
+            }
+            parallel.sync()
+            serial.sync()
+            XCTAssertNil(parallel.runtimeFailure, label)
+            assertBitwiseEqualStates(parallel, serial, bodies: bodies, label)
+        }
+    }
+
+    /// A single tet solid without cloth vertices never emits a V-T or E-E
+    /// contact (the kernels drop every same-solid candidate), so skipping the
+    /// element grid and both emitters must leave the trajectory untouched.
+    func testSurfaceEmissionSkipIsExactForSingleSolid() throws {
+        var scene = Demos.softbody()
+        scene.settings.deterministic = true
+        let bodies = Array(0..<scene.bodies.count)
+        let skipping = try makeGPU(scene)
+        let emitting = try makeGPU(scene)
+        emitting.forceSurfaceEmissionForTesting = true
+        for s in [skipping, emitting] { s.surfaceTruncationMode = .isotropicDAT }
+        XCTAssertGreaterThan(skipping.numTris, 0, "fixture needs boundary faces")
+        for _ in 0..<120 {
+            skipping.step()
+            emitting.step()
+        }
+        skipping.sync()
+        emitting.sync()
+        XCTAssertNil(skipping.runtimeFailure)
+        XCTAssertLessThan(skipping.dispatchesLastFrame,
+                          emitting.dispatchesLastFrame,
+                          "the skip must remove dispatches")
+        assertBitwiseEqualStates(skipping, emitting, bodies: bodies, "softbody")
+    }
+
+    func testDynamicColorTailIsBitwiseExact() throws {
+        for (label, torsion) in [("plain", false), ("torsion", true)] {
+            var scene = Demos.cloth(res: 12, ball: true)
+            scene.settings.deterministic = true
+            if torsion {
+                for i in scene.colliders.indices {
+                    scene.colliders[i].torsionalFriction = 0.02
+                }
+            }
+            let bodies = Array(0..<scene.bodies.count)
+            let loop = try makeGPU(scene)
+            let tail = try makeGPU(scene)
+            loop.surfaceTruncationMode = .isotropicDAT
+            tail.surfaceTruncationMode = .isotropicDAT
+            loop.colorBoundMarginForTesting = AVBD_MAX_COLORS
+            tail.colorBoundMarginForTesting = -AVBD_MAX_COLORS
+            var tailDispatches = 0
+            tail.solveDispatchObserverForTesting = {
+                if case .primalTail = $0 { tailDispatches += 1 }
+            }
+            for _ in 0..<120 {
+                loop.step()
+                tail.step()
+            }
+            loop.sync()
+            tail.sync()
+            XCTAssertNil(tail.runtimeFailure, label)
+            XCTAssertEqual(loop.lastColorTailColors, 0, label)
+            XCTAssertEqual(tail.lastColorTailColors,
+                           tail.lastMaxColorUsed + 1, label)
+            XCTAssertGreaterThan(tailDispatches, 0, label)
+            XCTAssertGreaterThan(tail.lastNumSoft, 0, label)
+            let a = loop.bodyStates(bodies)
+            let b = tail.bodyStates(bodies)
+            var mismatches = 0
+            for i in a.indices where a[i].position.x.bitPattern
+                != b[i].position.x.bitPattern
+                || a[i].position.y.bitPattern != b[i].position.y.bitPattern
+                || a[i].position.z.bitPattern != b[i].position.z.bitPattern
+                || a[i].linearVelocity.x.bitPattern
+                    != b[i].linearVelocity.x.bitPattern
+                || a[i].rotation.real.bitPattern
+                    != b[i].rotation.real.bitPattern {
+                mismatches += 1
+            }
+            XCTAssertEqual(mismatches, 0,
+                "\(label): \(mismatches) of \(bodies.count) bodies differ "
+                    + "between the dispatched loop and the colour tail "
+                    + "(colours \(tail.lastMaxColorUsed + 1))")
+        }
+    }
+
     func testDeformableContactTrajectoryIsBitwiseDeterministic() throws {
         // res 12 stays under the 1024-body ordered-coloring limit; res 34
         // exceeds it and exercises the compact multi-slot neighbor stream.
@@ -897,6 +1022,7 @@ final class GPUSolverTests: XCTestCase {
                     + "between two identical solvers")
         }
     }
+
 
     func testContactRichTrajectoryIsBitwiseDeterministic() throws {
         var scene = PhysicsScene(name: "deterministic-contact-grid")

--- a/Tests/PhysicsAVBDTests/SoftBodyTests.swift
+++ b/Tests/PhysicsAVBDTests/SoftBodyTests.swift
@@ -184,6 +184,42 @@ final class SoftBodyTests: XCTestCase {
                              "heavy rigid ball must rest ON the soft block (two-way coupling)")
     }
 
+    /// A plush-stiffness block (E ~ 1.5 kPa) under a heavy plate flattens to
+    /// a sheet with the bare stable Neo-Hookean model; compaction stiffening
+    /// must let it keep a meaningful thickness while leaving the unloaded
+    /// block's rest height unchanged.
+    func testTetCompactionStiffeningKeepsCrushedPlushThick() throws {
+        func crushedThickness(onset: Float, gain: Float) throws -> Float {
+            var scene = PhysicsScene(name: "plush-compaction")
+            scene.settings.iterations = 20
+            scene.settings.betaLin = 20000
+            scene.settings.lambdaMax = 800
+            scene.settings.tetCompactionOnset = onset
+            scene.settings.tetCompactionGain = gain
+            Demos.addGround(&scene)
+            let ids = Demos.addSoftBlock(&scene, center: F3(0, 0, 0.6), nx: 5, ny: 5, nz: 4,
+                                         spacing: 0.3, mu: 600, lambda: 600,
+                                         massPerNode: 0.02)
+            _ = scene.addBody(size: F3(2.0, 2.0, 0.2), density: 400,
+                              friction: 0.6, position: F3(0, 0, 1.8))
+            let gpu = try GPUSolver(scene: scene)
+            for _ in 0..<400 { gpu.step() }
+            gpu.sync()
+            let states = gpu.bodyStates(ids)
+            XCTAssertNil(gpu.runtimeFailure)
+            let zs = states.map(\.position.z)
+            return zs.max()! - zs.min()!
+        }
+        let bare = try crushedThickness(onset: 0, gain: 0)
+        let stiffened = try crushedThickness(onset: 0.6, gain: 30)
+        print("compaction test: bare \(bare) stiffened \(stiffened) (rest 0.9)")
+        XCTAssertLessThan(bare, 0.35, "the bare model must flatten under this plate")
+        XCTAssertGreaterThan(stiffened, bare * 1.6,
+            "compaction stiffening must resist the crush well beyond the bare model")
+        XCTAssertLessThan(stiffened, 0.9,
+            "stiffening below the onset must not prevent ordinary compression")
+    }
+
     func testBallRestsOnSoftBunny() throws {
         let scene = Demos.softbody(res: 10)
         var ball = -1

--- a/Tests/PhysicsAVBDTests/SoftBodyTests.swift
+++ b/Tests/PhysicsAVBDTests/SoftBodyTests.swift
@@ -394,6 +394,57 @@ final class SoftBodyTests: XCTestCase {
         XCTAssertTrue(gpu.bodyPosition(1).z.isFinite)
     }
 
+    func testGPUHashGridSkinBindingReconstructsContainedVertices() throws {
+        var scene = PhysicsScene(name: "gpu-skin-bind")
+        let positions = [
+            F3(0, 0, 0), F3(1, 0, 0),
+            F3(0, 1, 0), F3(0, 0, 1),
+        ]
+        let bodies = positions.map {
+            scene.addParticle(radius: 0.01, mass: 1, position: $0)
+        }
+        scene.addTet(SceneTet(
+            ids: (bodies[0], bodies[1], bodies[2], bodies[3]),
+            mu: 100, lambda: 200))
+        let visualPositions = [
+            F3(0.1, 0.2, 0.3), F3(0.25, 0.25, 0.25),
+            F3(0.7, 0.1, 0.1),
+        ]
+        let mesh = SurfaceMesh(
+            vertices: visualPositions,
+            normals: [F3](repeating: F3(0, 0, 1), count: 3),
+            triangles: [(0, 1, 2)])
+        let index = Demos.TetBindIndex(tets: scene.tets, scene: scene)
+        let binder = try XCTUnwrap(SkinBindGPU.shared,
+            "the GPU binding regression requires a Metal device")
+        let picks = try XCTUnwrap(binder.bind(mesh: mesh, index: index))
+        XCTAssertEqual(picks.count, visualPositions.count)
+
+        for (expected, pick) in zip(visualPositions, picks) {
+            XCTAssertEqual(pick.record, 0)
+            let w = pick.weights
+            let reconstructed = positions[0] * w.x + positions[1] * w.y
+                + positions[2] * w.z + positions[3] * w.w
+            XCTAssertLessThan(length(reconstructed - expected), 1e-5)
+            XCTAssertGreaterThanOrEqual(
+                min(min(w.x, w.y), min(w.z, w.w)), -1e-4)
+            XCTAssertEqual(w.x + w.y + w.z + w.w, 1, accuracy: 1e-5)
+        }
+    }
+
+    func testBindingWithoutValidTetsReturnsStructurallyEmptyMesh() {
+        let mesh = SurfaceMesh(
+            vertices: [F3.zero, F3(1, 0, 0), F3(0, 1, 0)],
+            normals: [F3](repeating: F3(0, 0, 1), count: 3),
+            triangles: [(0, 1, 2)])
+        let bound = Demos.bindVisualMesh(
+            mesh, scene: PhysicsScene(name: "no-tets"),
+            tetRange: 0..<0, bodyIDs: [])
+        XCTAssertTrue(bound.vertices.isEmpty)
+        XCTAssertTrue(bound.triangles.isEmpty,
+            "an empty vertex buffer must not retain dangling triangle indices")
+    }
+
     func testMeshSoftBodiesDropOnPinnedClothBuilds() throws {
         let scene = Demos.meshclothdrop(res: 10, scale: 1)
         XCTAssertGreaterThanOrEqual(scene.skinnedMeshes.count, 2)

--- a/Tests/PhysicsAVBDTests/SoftBodyTests.swift
+++ b/Tests/PhysicsAVBDTests/SoftBodyTests.swift
@@ -275,6 +275,86 @@ final class SoftBodyTests: XCTestCase {
             "stiffening below the onset must not prevent ordinary compression")
     }
 
+    func testTetCompactionSettingsSyncAtRuntime() throws {
+        var scene = PhysicsScene(name: "runtime-compaction-settings")
+        scene.settings.gravity = 0
+        let p0 = scene.addParticle(radius: 0.02, mass: 1,
+                                   position: F3(0, 0, 0))
+        let p1 = scene.addParticle(radius: 0.02, mass: 1,
+                                   position: F3(1, 0, 0))
+        let p2 = scene.addParticle(radius: 0.02, mass: 1,
+                                   position: F3(0, 1, 0))
+        let p3 = scene.addParticle(radius: 0.02, mass: 1,
+                                   position: F3(0, 0, 1))
+        scene.addTet(SceneTet(ids: (p0, p1, p2, p3), mu: 100, lambda: 200))
+        let solver = try GPUSolver(scene: scene)
+
+        solver.settings.tetCompactionOnset = 0.57
+        solver.settings.tetCompactionGain = 13
+        try solver.submitStep()
+        try solver.synchronize()
+        XCTAssertEqual(solver.params.tetCompactionOnset, 0.57, accuracy: 1e-7)
+        XCTAssertEqual(solver.params.tetCompactionGain, 13, accuracy: 1e-7)
+
+        solver.settings.tetCompactionOnset = -1
+        solver.settings.tetCompactionGain = -2
+        try solver.submitStep()
+        try solver.synchronize()
+        XCTAssertEqual(solver.params.tetCompactionOnset, 0)
+        XCTAssertEqual(solver.params.tetCompactionGain, 0)
+    }
+
+    func testZeroTetCompactionOnsetDisablesPenaltyForInvertedTet() throws {
+        func run(gain: Float) throws -> [GPUSolver.RigidBodyState] {
+            var scene = PhysicsScene(name: "zero-onset-inverted-tet")
+            scene.settings.dt = 1 / 120
+            scene.settings.gravity = 0
+            scene.settings.iterations = 1
+            scene.settings.tetCompactionOnset = 0
+            scene.settings.tetCompactionGain = gain
+            let rest = [
+                F3(0, 0, 0), F3(1, 0, 0),
+                F3(0, 1, 0), F3(0, 0, 1),
+            ]
+            let ids = rest.map {
+                scene.addParticle(radius: 0.01, mass: 1, position: $0)
+            }
+            scene.addTet(SceneTet(
+                ids: (ids[0], ids[1], ids[2], ids[3]),
+                mu: 500, lambda: 1_000))
+            let solver = try GPUSolver(scene: scene)
+            // Swap two vertices after construction so the current signed
+            // volume is negative relative to the authored rest tetrahedron.
+            solver.setBodyStates([
+                .init(body: ids[1], position: rest[2], rotation: Quat(),
+                      linearVelocity: .zero, angularVelocity: .zero),
+                .init(body: ids[2], position: rest[1], rotation: Quat(),
+                      linearVelocity: .zero, angularVelocity: .zero),
+            ])
+            try solver.submitStep()
+            try solver.synchronize()
+            XCTAssertNil(solver.runtimeFailure)
+            return solver.bodyStates(ids)
+        }
+
+        let disabledByGain = try run(gain: 0)
+        let disabledByOnset = try run(gain: 50)
+        for (expected, actual) in zip(disabledByGain, disabledByOnset) {
+            XCTAssertEqual(actual.position.x.bitPattern,
+                           expected.position.x.bitPattern)
+            XCTAssertEqual(actual.position.y.bitPattern,
+                           expected.position.y.bitPattern)
+            XCTAssertEqual(actual.position.z.bitPattern,
+                           expected.position.z.bitPattern)
+            XCTAssertEqual(actual.linearVelocity.x.bitPattern,
+                           expected.linearVelocity.x.bitPattern)
+            XCTAssertEqual(actual.linearVelocity.y.bitPattern,
+                           expected.linearVelocity.y.bitPattern)
+            XCTAssertEqual(actual.linearVelocity.z.bitPattern,
+                           expected.linearVelocity.z.bitPattern)
+        }
+    }
+
     func testBallRestsOnSoftBunny() throws {
         let scene = Demos.softbody(res: 10)
         var ball = -1


### PR DESCRIPTION
## Summary

Stacked on #16. Opt-in compaction stiffening for tetrahedral soft bodies.

The stable Neo-Hookean volume term `lambda/2 (J - alpha)^2` saturates as a tet is crushed toward `J = 0`, so a low-modulus plush pinched by a torque-limited gripper flattens into a sheet with nothing left to grip. That is exactly what the MicroDuck pickup traces showed at 1.5 kPa: bite angles of 0.02 rad at handoff and 0.1 to 0.3 m of probe slip. Real stuffing compacts freely and then stiffens sharply.

`SimSettings.tetCompactionOnset` and `tetCompactionGain` (both 0 by default, meaning off) add a quadratic bulk penalty of `gain * lambda` below the onset volume ratio, with the matching Gauss-Newton Hessian contribution. Softness in bending, shear and moderate compression is untouched. Two trailing `SimParams` floats carry the values; all four `stampTet` call sites pass them.

## Test plan

- [x] New `testTetCompactionStiffeningKeepsCrushedPlushThick`: a 5x5x4 block at mu = lambda = 600 Pa under a heavy plate flattens from 0.90 to 0.18 with the bare model and keeps 0.72 with onset 0.6 and gain 30, and it still compresses (not rigid).
- [x] `SoftBodyTests`, `ClothTests`, `PlanarDATTests`, `ConvexDeformableCollisionTests`, `GPUSolverTests` with the default (off): 114 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
