### PR TITLE
Small-scene GPU frame cost: parallel bucket sorts, exact emitter skip, colour tail

### DIFF
--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -169,6 +169,7 @@ public final class GPUSolver {
     var tets: MTLBuffer
     var hashedIdx, globalIdx, hashedRigidIdx: MTLBuffer
     var cellCount, cellStart, cellBodies, cellRigid: MTLBuffer
+    var cellBodiesSorted: MTLBuffer
     var bodyCellSlot: MTLBuffer
     public let usesRigidColliderHierarchy: Bool
     public let rigidBroadphaseProxyCount: Int
@@ -284,6 +285,7 @@ public final class GPUSolver {
 
     // Adjacency + coloring
     var degrees, adjStart, adjCursor, adjList, adjNeighbor: MTLBuffer
+    var adjListSorted, adjSlotBody: MTLBuffer
     var colorsA, colorsB, bodySlot, colorStart, colorList: MTLBuffer
     var changedFlag: MTLBuffer
 
@@ -324,6 +326,11 @@ public final class GPUSolver {
         "bp_finalize_deterministic_pairs",
         "bp_scatter",
         "bp_sort_cells",
+        "bp_rank_cells",
+        "primal_particles_split_tail",
+        "primal_rigid_split_tail",
+        "primal_particles_split_torsion_tail",
+        "adj_rank",
         "build_instances",
         "color_count",
         "color_iterate",
@@ -1527,6 +1534,8 @@ public final class GPUSolver {
         cellStart = try makeBuf(gridHashSize * 4, "cellStart")
         cellBodies = try makeBuf(max(1, broadphaseItemCount) * 4,
                                  "cellBodies")
+        cellBodiesSorted = try makeBuf(max(1, broadphaseItemCount) * 4,
+                                       "cellBodiesSorted")
         bodyCellSlot = try makeBuf(max(1, broadphaseItemCount) * 8,
                                    "bodyCellSlot")
         pairCount = try makeBuf(max(maxPairs, broadphaseItemCount) * 4,
@@ -1613,6 +1622,8 @@ public final class GPUSolver {
         let adjacencyCapacity = 2 * (numJoints + numSprings + maxPairs)
             + 4 * numTets + 4 * maxSoft + 3 * numTris + 4 * maxEdges
         adjList = try makeBuf(adjacencyCapacity * 4, "adjList")
+        adjListSorted = try makeBuf(adjacencyCapacity * 4, "adjListSorted")
+        adjSlotBody = try makeBuf(adjacencyCapacity * 4, "adjSlotBody")
         let compactNeighborCapacity =
             ((numTris == 0 && numTets == 0) || deterministicColoring)
             && numBodies > Self.orderedColoringBodyLimit
@@ -3457,13 +3468,71 @@ public final class GPUSolver {
         }
     }
 
+    /// Compute dispatches encoded by the most recent frame. Small scenes are
+    /// launch-bound, so this is the number to watch when a frame's GPU time
+    /// does not track its arithmetic.
+    public private(set) var dispatchesLastFrame = 0
+    /// V-T and E-E emission drop every candidate inside one solid (the
+    /// `sameSolid_` gate in the kernels), so a scene whose surface elements
+    /// all belong to a single solid without cloth vertices never emits a
+    /// surface contact. Skipping the element grid and both emitters there is
+    /// exact. Rigid-vs-triangle emission is independent and still runs.
+    private lazy var surfaceEmissionNeeded: Bool = {
+        guard numTris > 0 else { return false }
+        let groups = clothGroupBuf.contents()
+            .bindMemory(to: UInt32.self, capacity: numBodies)
+        let cloth = clothVertFlag.contents()
+            .bindMemory(to: UInt32.self, capacity: numBodies)
+        let tris = trisBuf.contents()
+            .bindMemory(to: SIMD4<UInt32>.self, capacity: numTris)
+        let particles = particleIdxBuf.contents()
+            .bindMemory(to: UInt32.self, capacity: max(1, numParticles))
+        var solidGroups = Set<UInt32>()
+        func touches(_ v: Int) -> Bool {
+            if groups[v] == 0 || cloth[v] != 0 { return true }
+            solidGroups.insert(groups[v])
+            return false
+        }
+        for i in 0..<numParticles where touches(Int(particles[i])) {
+            return true
+        }
+        for t in 0..<numTris {
+            let ids = tris[t]
+            if touches(Int(ids.x)) || touches(Int(ids.y))
+                || touches(Int(ids.z)) { return true }
+        }
+        return solidGroups.count > 1
+    }()
+    /// Broadphase sizing of the current scene, for profiling output.
+    public var debugSceneCounts: [String: Int] {
+        ["hashed": Int(params.numHashed), "globals": Int(params.numGlobals),
+         "hashedRigid": Int(params.numHashedRigid), "tris": numTris,
+         "particles": numParticles, "gridHashSize": gridHashSize,
+         "rigidProxies": rigidBroadphaseProxyCount, "maxPairs": maxPairs,
+         "bodies": numBodies,
+         "cellSizeMicrons": Int(params.cellSize * 1e6),
+         "elemCellSizeMicrons": Int(params.elemCellSize * 1e6),
+         "elemHashSize": Int(params.elemHashSize)]
+    }
+    private var dispatchesThisFrame = 0
+    /// Per-kernel tally of the most recent frame's dispatches; raw
+    /// dispatchThreadgroups calls (the solve loop) are tallied as "raw".
+    public private(set) var dispatchNamesLastFrame: [String: Int] = [:]
+    private var dispatchNamesThisFrame: [String: Int] = [:]
+    private func noteDispatch(_ name: String) {
+        dispatchesThisFrame += 1
+        dispatchNamesThisFrame[name, default: 0] += 1
+    }
+
     private func dispatch1D(_ enc: MTLComputeCommandEncoder, _ name: String, _ count: Int,
                             _ setup: (MTLComputeCommandEncoder) -> Void) {
         guard count > 0 else { return }
+        noteDispatch(name)
         let p = ps(name)
         enc.setComputePipelineState(p)
         setup(enc)
         let tg = min(p.maxTotalThreadsPerThreadgroup, 256)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: (count + tg - 1) / tg, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: tg, height: 1, depth: 1))
     }
@@ -3471,9 +3540,11 @@ public final class GPUSolver {
     private func dispatchIndirect(_ enc: MTLComputeCommandEncoder, _ name: String,
                                   argsOffset: Int,
                                   _ setup: (MTLComputeCommandEncoder) -> Void) {
+        noteDispatch(name)
         let p = ps(name)
         enc.setComputePipelineState(p)
         setup(enc)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(indirectBuffer: dispatchArgs,
                                  indirectBufferOffset: argsOffset * 4,
                                  threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
@@ -3490,6 +3561,7 @@ public final class GPUSolver {
         enc.setBuffer(output, offset: 0, index: 1)
         enc.setBuffer(scanBlockSums, offset: 0, index: 2)
         enc.setBytes(&c, length: 4, index: 3)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: blocks, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
 
@@ -3499,6 +3571,7 @@ public final class GPUSolver {
         enc.setBuffer(scanBlockSums, offset: 0, index: 0)
         enc.setBytes(&nb, length: 4, index: 1)
         enc.setBuffer(scanTotal, offset: 0, index: 2)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
 
@@ -3526,6 +3599,9 @@ public final class GPUSolver {
         let counterSnapshot: MTLBuffer
         let frame: Int
         let usesDynamicColoring: Bool
+        /// First colour handed to the colour tail (AVBD_MAX_COLORS when
+        /// the per-colour loop covered the whole palette).
+        let colorBound: Int
         let softCapacity: Int
         let planarDATCapacity: Int
     }
@@ -3553,10 +3629,29 @@ public final class GPUSolver {
     var planarDATBodyIncidenceForTesting = false
     var planarDATPassObserverForTesting: ((PlanarDATPassSite) -> Void)?
     var persistentSolveForTesting = false
+    /// Colours dispatched per iteration beyond the last known palette size
+    /// before the colour tail takes over. Palettes grow by a few colours
+    /// when a contact cluster forms; eight keeps the tail idle in practice.
+    static let colorBoundMargin = 8
+    /// Overrides the margin (may be negative) so tests can force every
+    /// colour through the tail and compare against the dispatched loop.
+    var colorBoundMarginForTesting: Int?
+    /// Routes the broadphase bucket sort and the adjacency sort through the
+    /// original serial insertion-sort kernels so tests can show the
+    /// parallel rank sorts reproduce them exactly.
+    var legacySerialSortsForTesting = false
+    /// Runs the element grid and the V-T/E-E emitters even when
+    /// `surfaceEmissionNeeded` proves they cannot emit, for the same purpose.
+    var forceSurfaceEmissionForTesting = false
+    /// Colours solved by the tail dispatch in the most recently retired
+    /// frame (0 when the bounded loop covered the palette).
+    public private(set) var lastColorTailColors = 0
     enum SolveDispatchForTesting: Equatable {
         case primal(torsion: Bool)
         case dual(torsion: Bool)
         case persistent(torsion: Bool)
+        /// Single-threadgroup solve of the colours beyond the bounded loop.
+        case primalTail
     }
     var solveDispatchObserverForTesting: ((SolveDispatchForTesting) -> Void)?
     var convexQueryFailureForTesting = false
@@ -3651,6 +3746,7 @@ public final class GPUSolver {
         enc.setBuffer(out, offset: 0, index: 3)
         var r32 = UInt32(res)
         enc.setBytes(&r32, length: 4, index: 4)
+        noteDispatch("raw")
         enc.dispatchThreadgroups(MTLSize(width: (res + 7) / 8, height: (res + 7) / 8,
                                          depth: numEnvs),
                                  threadsPerThreadgroup: MTLSize(width: 8, height: 8, depth: 1))
@@ -4447,6 +4543,7 @@ public final class GPUSolver {
             }
             lastColorCounts = counts
             lastMaxColorUsed = maxUsed
+            lastColorTailColors = max(0, maxUsed + 1 - submission.colorBound)
         }
         statsLock.unlock()
 
@@ -4763,7 +4860,7 @@ public final class GPUSolver {
         let d = MTLCounterSampleBufferDescriptor()
         d.counterSet = set
         d.storageMode = .shared
-        d.sampleCount = 128
+        d.sampleCount = 512
         counterBuf = try? device.makeCounterSampleBuffer(descriptor: d)
         return counterBuf
     }
@@ -4851,7 +4948,7 @@ public final class GPUSolver {
         stageNames = []
         func makeEncoder(_ name: String) -> MTLComputeCommandEncoder? {
             if deniedEncoderStageForTesting == name { return nil }
-            guard let sampleBuf, stageNames.count < 63 else {
+            guard let sampleBuf, stageNames.count < 255 else {
                 let e = cmd1.makeComputeCommandEncoder()
                 e?.label = name
                 return e
@@ -4980,6 +5077,7 @@ public final class GPUSolver {
                 encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                                  index: 15)
                 encoder.setBuffer(self.edgesBuf, offset: 0, index: 19)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     MTLSize(width: numParticles, height: 1, depth: 1),
                     threadsPerThreadgroup: MTLSize(width: 64, height: 1,
@@ -5006,6 +5104,7 @@ public final class GPUSolver {
                 encoder.setBuffer(self.counters, offset: 0, index: 14)
                 encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                                  index: 15)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     MTLSize(width: Int(P.numEdges), height: 1, depth: 1),
                     threadsPerThreadgroup: MTLSize(width: 64, height: 1,
@@ -5060,6 +5159,7 @@ public final class GPUSolver {
             // these exact step-start coordinates rather than double-counting
             // predictor displacement.
             encoder.setBuffer(referencePositions, offset: 0, index: 16)
+            noteDispatch("raw")
             encoder.dispatchThreadgroups(
                 indirectBuffer: planarDATArgsBuf,
                 indirectBufferOffset: 0,
@@ -5081,6 +5181,7 @@ public final class GPUSolver {
             encoder.setBuffer(edgesBuf, offset: 0, index: 4)
             encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                              index: 5)
+            noteDispatch("raw")
             encoder.dispatchThreadgroups(
                 indirectBuffer: planarDATArgsBuf,
                 indirectBufferOffset: 0,
@@ -5102,6 +5203,7 @@ public final class GPUSolver {
             encoder.setBuffer(edgesBuf, offset: 0, index: 5)
             encoder.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                              index: 6)
+            noteDispatch("raw")
             encoder.dispatchThreadgroups(
                 indirectBuffer: planarDATArgsBuf,
                 indirectBufferOffset: 0,
@@ -5218,6 +5320,7 @@ public final class GPUSolver {
                     encoder.setBuffer(self.planarDATBodyPairsBuf, offset: 0,
                                       index: 14)
                     let threads = self.lastColorCounts[activeColor] * 8
+                    noteDispatch("raw")
                     encoder.dispatchThreadgroups(
                         MTLSize(width: (threads + 63) / 64,
                                 height: 1, depth: 1),
@@ -5226,6 +5329,7 @@ public final class GPUSolver {
                 } else {
                     encoder.setBuffer(colorsA, offset: 0, index: 9)
                     encoder.setBytes(&color, length: 4, index: 10)
+                    noteDispatch("raw")
                     encoder.dispatchThreadgroups(
                         indirectBuffer: planarDATArgsBuf,
                         indirectBufferOffset: 0,
@@ -5245,6 +5349,7 @@ public final class GPUSolver {
                                  length: MemoryLayout<SimParamsGPU>.stride,
                                  index: 8)
                 encoder.setBytes(&color, length: 4, index: 9)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     indirectBuffer: self.colorArgs,
                     indirectBufferOffset: activeColor * 12,
@@ -5254,6 +5359,7 @@ public final class GPUSolver {
                 encoder.setBuffer(colorsA, offset: 0, index: 9)
                 var fullPass = UInt32.max
                 encoder.setBytes(&fullPass, length: 4, index: 10)
+                noteDispatch("raw")
                 encoder.dispatchThreadgroups(
                     indirectBuffer: planarDATArgsBuf,
                     indirectBufferOffset: 0,
@@ -5312,6 +5418,7 @@ public final class GPUSolver {
         let broadphasePairOutput = usesRigidColliderHierarchy
             ? broadphaseProxyPairs : pairs
         if profiling { try stage("bp-count") }
+        if profiling { try stage("bp-count/bp_count") }
         dispatch1D(enc, "bp_count", Int(P.numHashed)) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.hashedIdx, offset: 0, index: 1)
@@ -5326,8 +5433,10 @@ public final class GPUSolver {
             e.setBuffer(bpGroup, offset: 0, index: 10)
         }
         if profiling { try stage("bp-scan") }
+        if profiling { try stage("bp-scan/scan") }
         encodeScan(enc, input: cellCount, output: cellStart, count: gridHashSize)
         if profiling { try stage("bp-scatter") }
+        if profiling { try stage("bp-scatter/bp_scatter") }
         dispatch1D(enc, "bp_scatter", Int(P.numHashed)) { e in
             e.setBuffer(self.hashedIdx, offset: 0, index: 0)
             e.setBuffer(self.bodyCellSlot, offset: 0, index: 1)
@@ -5335,14 +5444,31 @@ public final class GPUSolver {
             e.setBuffer(self.cellBodies, offset: 0, index: 3)
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
         }
-        var hashSize32 = UInt32(gridHashSize)
-        dispatch1D(enc, "bp_sort_cells", gridHashSize) { e in
-            e.setBuffer(self.cellStart, offset: 0, index: 0)
-            e.setBuffer(self.cellCount, offset: 0, index: 1)
-            e.setBuffer(self.cellBodies, offset: 0, index: 2)
-            e.setBytes(&hashSize32, length: 4, index: 3)
+        if legacySerialSortsForTesting {
+            var hashSize32 = UInt32(gridHashSize)
+            dispatch1D(enc, "bp_sort_cells", gridHashSize) { e in
+                e.setBuffer(self.cellStart, offset: 0, index: 0)
+                e.setBuffer(self.cellCount, offset: 0, index: 1)
+                e.setBuffer(self.cellBodies, offset: 0, index: 2)
+                e.setBytes(&hashSize32, length: 4, index: 3)
+            }
+        } else {
+        if profiling { try stage("bp-scatter/bp_rank_cells") }
+        dispatch1D(enc, "bp_rank_cells", Int(P.numHashed)) { e in
+            e.setBuffer(self.hashedIdx, offset: 0, index: 0)
+            e.setBuffer(self.bodyCellSlot, offset: 0, index: 1)
+            e.setBuffer(self.cellStart, offset: 0, index: 2)
+            e.setBuffer(self.cellCount, offset: 0, index: 3)
+            e.setBuffer(self.cellBodies, offset: 0, index: 4)
+            e.setBuffer(self.cellBodiesSorted, offset: 0, index: 5)
+            e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 6)
+        }
+        // Every later reader binds `cellBodies`; the scatter target and the
+        // sorted copy alternate roles frame by frame.
+        swap(&cellBodies, &cellBodiesSorted)
         }
         if numTris > 0 && P.numHashedRigid > 8 {
+            if profiling { try stage("bp-scatter/rt_pack_spatial_index") }
             dispatch1D(enc, "rt_pack_spatial_index",
                        max(gridHashSize, Int(P.numHashed))) { e in
                 e.setBuffer(self.cellStart, offset: 0, index: 0)
@@ -5356,6 +5482,7 @@ public final class GPUSolver {
         if profiling { try stage("bp-pairs") }
         let pairProducerCount = Int(P.numHashed + P.numGlobals)
         if pairProducerCount > 0 {
+            if profiling { try stage("bp-pairs/bp_count_pairs_deterministic") }
             dispatch1D(enc, "bp_count_pairs_deterministic", pairProducerCount) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(bpShape, offset: 0, index: 1)
@@ -5378,8 +5505,10 @@ public final class GPUSolver {
                 e.setBuffer(bpSharedCollision, offset: 0, index: 18)
                 e.setBuffer(bpShapeType, offset: 0, index: 19)
             }
+            if profiling { try stage("bp-pairs/scan") }
             encodeScan(enc, input: pairCount, output: pairStart,
                        count: pairProducerCount)
+            if profiling { try stage("bp-pairs/bp_emit_pairs_deterministic") }
             dispatch1D(enc, "bp_emit_pairs_deterministic", pairProducerCount) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(bpShape, offset: 0, index: 1)
@@ -5403,6 +5532,7 @@ public final class GPUSolver {
                 e.setBuffer(bpShapeType, offset: 0, index: 19)
             }
         }
+        if profiling { try stage("bp-pairs/bp_finalize_deterministic_pairs") }
         dispatch1D(enc, "bp_finalize_deterministic_pairs", 1) { e in
             e.setBuffer(self.pairCount, offset: 0, index: 0)
             e.setBuffer(self.pairStart, offset: 0, index: 1)
@@ -5411,6 +5541,7 @@ public final class GPUSolver {
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
         }
         if usesRigidColliderHierarchy {
+            if profiling { try stage("bp-pairs/bp_count_hierarchy_pairs") }
             dispatch1D(enc, "bp_count_hierarchy_pairs", maxPairs) { e in
                 e.setBuffer(self.broadphaseProxyPairs, offset: 0, index: 0)
                 e.setBuffer(self.counters, offset: 0, index: 1)
@@ -5428,8 +5559,10 @@ public final class GPUSolver {
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                            index: 13)
             }
+            if profiling { try stage("bp-pairs/scan") }
             encodeScan(enc, input: pairCount, output: pairStart,
                        count: maxPairs)
+            if profiling { try stage("bp-pairs/bp_emit_hierarchy_pairs") }
             dispatch1D(enc, "bp_emit_hierarchy_pairs", maxPairs) { e in
                 e.setBuffer(self.broadphaseProxyPairs, offset: 0, index: 0)
                 e.setBuffer(self.counters, offset: 0, index: 1)
@@ -5447,6 +5580,7 @@ public final class GPUSolver {
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
                            index: 13)
             }
+            if profiling { try stage("bp-pairs/bp_finalize_hierarchy_pairs") }
             dispatch1D(enc, "bp_finalize_hierarchy_pairs", 1) { e in
                 e.setBuffer(self.pairCount, offset: 0, index: 0)
                 e.setBuffer(self.pairStart, offset: 0, index: 1)
@@ -5539,6 +5673,7 @@ public final class GPUSolver {
             }
         }
         if convexQueryFailureForTesting {
+            if profiling { try stage("narrowphase/convex_query_fail_for_testing") }
             dispatch1D(enc, "convex_query_fail_for_testing", 1) { e in
                 e.setBuffer(self.counters, offset: 0, index: 0)
                 e.setBuffer(self.colliderHullRange, offset: 0, index: 1)
@@ -5570,11 +5705,13 @@ public final class GPUSolver {
 
         try stage("persistence-map")
         // Rebuild persistence map from THIS frame's manifolds (for next frame)
+        if profiling { try stage("persistence-map/pm_clear") }
         dispatch1D(enc, "pm_clear", mapCapacity) { e in
             e.setBuffer(self.mapKeyA, offset: 0, index: 0)
             var cap = UInt32(self.mapCapacity)
             e.setBytes(&cap, length: 4, index: 1)
         }
+        if profiling { try stage("persistence-map/pm_insert") }
         dispatchIndirect(enc, "pm_insert", argsOffset: 0) { e in
             e.setBuffer(self.manifolds, offset: 0, index: 0)
             e.setBuffer(self.mapKeyA, offset: 0, index: 1)
@@ -5589,11 +5726,16 @@ public final class GPUSolver {
             // records remain on their existing start-pose path. The accepted
             // Planar stream is emitted after predictor acceptance below.
         if numTris > 0 {
-            if !isPlanarDAT {
+            if !isPlanarDAT, !surfaceEmissionNeeded,
+               !forceSurfaceEmissionForTesting {
+                // Single solid, no cloth: the emitters would drop every
+                // candidate (see surfaceEmissionNeeded). Exact skip.
+            } else if !isPlanarDAT {
             try stage("el-bin")
             encodeElementGrid(enc, clearFirst: false)
             try stage("vt-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_VT"] == nil {
+            if profiling { try stage("vt-emit/vt_emit") }
             dispatch1D(enc, "vt_emit", numParticles) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(self.shape, offset: 0, index: 1)
@@ -5666,6 +5808,7 @@ public final class GPUSolver {
             }
             try stage("rt-emit")
             if ProcessInfo.processInfo.environment["AVBD_NO_RT"] == nil {
+            if profiling { try stage("rt-emit/rt_emit") }
             dispatch1D(enc, "rt_emit", numTris) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(self.posAng, offset: 0, index: 1)
@@ -5790,10 +5933,12 @@ public final class GPUSolver {
         try stage("adjacency")
         // Adjacency
         var nb32 = UInt32(numBodies)
+        if profiling { try stage("adjacency/adj_clear_degrees") }
         dispatch1D(enc, "adj_clear_degrees", numBodies) { e in
             e.setBuffer(self.degrees, offset: 0, index: 0)
             e.setBytes(&nb32, length: 4, index: 1)
         }
+        if profiling { try stage("adjacency/adj_count") }
         dispatchIndirect(enc, "adj_count", argsOffset: 3) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.joints, offset: 0, index: 1)
@@ -5807,12 +5952,15 @@ public final class GPUSolver {
             e.setBuffer(self.membranes, offset: 0, index: 9)
             e.setBuffer(self.bends, offset: 0, index: 10)
         }
+        if profiling { try stage("adjacency/scan") }
         encodeScan(enc, input: degrees, output: adjStart, count: numBodies)
+        if profiling { try stage("adjacency/adj_copy_cursor") }
         dispatch1D(enc, "adj_copy_cursor", numBodies) { e in
             e.setBuffer(self.adjStart, offset: 0, index: 0)
             e.setBuffer(self.adjCursor, offset: 0, index: 1)
             e.setBytes(&nb32, length: 4, index: 2)
         }
+        if profiling { try stage("adjacency/adj_scatter") }
         dispatchIndirect(enc, "adj_scatter", argsOffset: 3) { e in
             e.setBuffer(self.posLin, offset: 0, index: 0)
             e.setBuffer(self.joints, offset: 0, index: 1)
@@ -5826,16 +5974,33 @@ public final class GPUSolver {
             e.setBuffer(self.softContacts, offset: 0, index: 9)
             e.setBuffer(self.membranes, offset: 0, index: 10)
             e.setBuffer(self.bends, offset: 0, index: 11)
+            e.setBuffer(self.adjSlotBody, offset: 0, index: 12)
         }
-        dispatch1D(enc, "adj_sort", numBodies) { e in
-            e.setBuffer(self.adjStart, offset: 0, index: 0)
-            e.setBuffer(self.degrees, offset: 0, index: 1)
-            e.setBuffer(self.adjList, offset: 0, index: 2)
-            e.setBytes(&nb32, length: 4, index: 3)
+        if legacySerialSortsForTesting {
+            dispatch1D(enc, "adj_sort", numBodies) { e in
+                e.setBuffer(self.adjStart, offset: 0, index: 0)
+                e.setBuffer(self.degrees, offset: 0, index: 1)
+                e.setBuffer(self.adjList, offset: 0, index: 2)
+                e.setBytes(&nb32, length: 4, index: 3)
+            }
+        } else {
+            if profiling { try stage("adjacency/adj_rank") }
+            dispatch1D(enc, "adj_rank", adjList.length / 4) { e in
+                e.setBuffer(self.adjStart, offset: 0, index: 0)
+                e.setBuffer(self.degrees, offset: 0, index: 1)
+                e.setBuffer(self.adjList, offset: 0, index: 2)
+                e.setBuffer(self.adjSlotBody, offset: 0, index: 3)
+                e.setBuffer(self.adjListSorted, offset: 0, index: 4)
+                e.setBytes(&nb32, length: 4, index: 5)
+            }
+            // Later readers bind `adjList`; scatter target and sorted copy
+            // alternate roles frame by frame.
+            swap(&adjList, &adjListSorted)
         }
         var neighborSlots32 = UInt32(neighborSlots)
         if usesDynamicColoring
             && numBodies > Self.orderedColoringBodyLimit {
+            if profiling { try stage("adjacency/adj_extract_neighbors") }
             dispatch1D(enc, "adj_extract_neighbors", numBodies) { e in
                 e.setBuffer(self.joints, offset: 0, index: 0)
                 e.setBuffer(self.springs, offset: 0, index: 1)
@@ -5880,6 +6045,7 @@ public final class GPUSolver {
             var src = colorsA, dst = colorsB
             let parallelColorPasses = 20
             for pass in 0..<parallelColorPasses {
+                if profiling { try stage("coloring/color_iterate") }
                 dispatch1D(enc, "color_iterate", numBodies) { e in
                     e.setBytes(&neighborSlots32, length: 4, index: 20)
                     e.setBuffer(self.posLin, offset: 0, index: 0)
@@ -5911,6 +6077,7 @@ public final class GPUSolver {
             // rare after settling and guarantees that validation never sees
             // an arbitrary iteration-limit artifact.
             var finalPass = UInt32(parallelColorPasses - 1)
+            if profiling { try stage("coloring/color_repair_greedy") }
             dispatch1D(enc, "color_repair_greedy", 1) { e in
                 e.setBytes(&neighborSlots32, length: 4, index: 20)
                 e.setBuffer(self.posLin, offset: 0, index: 0)
@@ -5931,6 +6098,7 @@ public final class GPUSolver {
                 e.setBytes(&finalPass, length: 4, index: 14)
                 e.setBuffer(self.adjNeighbor, offset: 0, index: 15)
             }
+            if profiling { try stage("coloring/color_validate") }
             dispatch1D(enc, "color_validate", numBodies) { e in
                 e.setBytes(&neighborSlots32, length: 4, index: 20)
                 e.setBuffer(self.posLin, offset: 0, index: 0)
@@ -5950,6 +6118,7 @@ public final class GPUSolver {
                 e.setBuffer(self.bends, offset: 0, index: 13)
                 e.setBuffer(self.adjNeighbor, offset: 0, index: 14)
             }
+            if profiling { try stage("coloring/color_count") }
             dispatch1D(enc, "color_count", numBodies) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(finalColors, offset: 0, index: 1)
@@ -5957,12 +6126,14 @@ public final class GPUSolver {
                 e.setBuffer(self.bodySlot, offset: 0, index: 3)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
             }
+            if profiling { try stage("coloring/color_scan") }
             dispatch1D(enc, "color_scan", AVBD_MAX_COLORS) { e in
                 e.setBuffer(self.counters, offset: 0, index: 0)
                 e.setBuffer(self.colorStart, offset: 0, index: 1)
                 e.setBuffer(self.colorArgs, offset: 0, index: 2)
                 e.setBytes(&primalThreadsPerBody, length: 4, index: 3)
             }
+            if profiling { try stage("coloring/color_scatter") }
             dispatch1D(enc, "color_scatter", numBodies) { e in
                 e.setBuffer(self.posLin, offset: 0, index: 0)
                 e.setBuffer(finalColors, offset: 0, index: 1)
@@ -5994,6 +6165,7 @@ public final class GPUSolver {
             }
         }
         try stage("solver-iterations")
+        var submittedColorBound = AVBD_MAX_COLORS
         let persistPSO = ps(hasTorsionalFriction
             ? "solve_persistent_torsion" : "solve_persistent")
         let multiPSO = ps("solve_persistent_multi")
@@ -6044,6 +6216,7 @@ public final class GPUSolver {
             enc.setBuffer(boundsBuf, offset: 0, index: 26)
             enc.setBuffer(ogcPrevBuf, offset: 0, index: 27)
             enc.setBuffer(counters, offset: 0, index: 28)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: Int(ntg), height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: tgW, height: 1, depth: 1))
         } else if persistentRequested && !isPlanarDAT
@@ -6085,6 +6258,7 @@ public final class GPUSolver {
                          ((max(numBodies, 64) + w - 1) / w) * w)
             solveDispatchObserverForTesting?(
                 .persistent(torsion: hasTorsionalFriction))
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: tg, height: 1, depth: 1))
         } else {
@@ -6092,8 +6266,27 @@ public final class GPUSolver {
         // buffer. Dispatch every representable color: zero-count indirect
         // calls are empty, while relying on an asynchronous CPU color bound
         // previously required a racy in-place "tail" solve.
-        let colorBound = usesDynamicColoring
-            ? AVBD_MAX_COLORS : staticUsedColors
+        // Dynamic palettes are sized on the GPU, so the CPU cannot know the
+        // exact colour count while encoding. Dispatching all 64 slots every
+        // iteration cost ~1000 empty dispatches per frame on a 16-colour
+        // scene. Instead bound the loop by the most recent readback plus a
+        // margin and let a single colour-tail dispatch solve any colours at
+        // or beyond the bound, exactly. The readback may be several frames
+        // stale under pipelining; that only moves work between the loop and
+        // the tail, never the result. Planar-DAT interleaves per-colour
+        // passes the tail does not replicate, and the scalar primal_solve
+        // has no tail, so both keep the full loop.
+        let usesColorTail = usesDynamicColoring && !isPlanarDAT && !noRSplit
+        let colorBound: Int
+        if usesColorTail {
+            let margin = colorBoundMarginForTesting ?? Self.colorBoundMargin
+            colorBound = max(0, min(AVBD_MAX_COLORS,
+                                    lastMaxColorUsed + 1 + margin))
+        } else {
+            colorBound = usesDynamicColoring
+                ? AVBD_MAX_COLORS : staticUsedColors
+        }
+        submittedColorBound = usesColorTail ? colorBound : AVBD_MAX_COLORS
         // Rigid scenes use the 8-lane cooperative split primal too: dense
         // piles average 12-27 manifolds/body and the one-thread-per-body
         // kernel was latency-bound walking them serially (boxpile x12
@@ -6200,10 +6393,12 @@ public final class GPUSolver {
                 solveDispatchObserverForTesting?(
                     .primal(torsion: hasTorsionalFriction))
                 if usesDynamicColoring {
+                    noteDispatch("raw")
                     enc.dispatchThreadgroups(indirectBuffer: colorArgs,
                                              indirectBufferOffset: c * 12,
                                              threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
                 } else {
+                    noteDispatch("raw")
                     enc.dispatchThreadgroups(
                         MTLSize(width: (splitSizes[c] + 63) / 64, height: 1, depth: 1),
                         threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
@@ -6241,6 +6436,23 @@ public final class GPUSolver {
                     enc.setBuffer(colorList, offset: 0, index: 13)
                     enc.setBuffer(colorStart, offset: 0, index: 14)
                 }
+            }
+            if usesColorTail && colorBound < AVBD_MAX_COLORS {
+                // Bindings 0-14 and 16-27 are still the primal's; only the
+                // pipeline and slot 15 (first tail colour) change.
+                let tailName = hasTorsionalFriction
+                    ? "primal_particles_split_torsion_tail"
+                    : (useWideRigidSplit ? "primal_rigid_split_tail"
+                                         : "primal_particles_split_tail")
+                var firstColor = UInt32(colorBound)
+                enc.setComputePipelineState(ps(tailName))
+                enc.setBytes(&firstColor, length: 4, index: 15)
+                solveDispatchObserverForTesting?(.primalTail)
+                noteDispatch(tailName)
+                enc.dispatchThreadgroups(
+                    MTLSize(width: 1, height: 1, depth: 1),
+                    threadsPerThreadgroup: MTLSize(width: 256, height: 1,
+                                                   depth: 1))
             }
             if profiling { try stage("solve-dual") }
             let dualName = hasTorsionalFriction
@@ -6297,6 +6509,7 @@ public final class GPUSolver {
                 enc.setBuffer(nbr2Start, offset: 0, index: 12)
                 enc.setBuffer(nbr2Count, offset: 0, index: 13)
                 enc.setBuffer(nbr2List, offset: 0, index: 14)
+                noteDispatch("raw")
                 enc.dispatchThreadgroups(indirectBuffer: ogcArgsBuf,
                                          indirectBufferOffset: 0,
                                          threadsPerThreadgroup: MTLSize(width: 64, height: 1, depth: 1))
@@ -6407,6 +6620,7 @@ public final class GPUSolver {
             commandBuffer: cmd1, counterSnapshot: counterSnapshot,
             frame: submittedFrame,
             usesDynamicColoring: usesDynamicColoring,
+            colorBound: submittedColorBound,
             softCapacity: Int(P.maxSoft),
             planarDATCapacity: Int(P.maxPlanarDATPairs))
         cmd1.commit()
@@ -6419,6 +6633,10 @@ public final class GPUSolver {
         }
         swap(&contactFeatures, &prevContactFeatures)
         if numTris > 0 { swap(&softContacts, &prevSoftContacts) }
+        dispatchesLastFrame = dispatchesThisFrame
+        dispatchesThisFrame = 0
+        dispatchNamesLastFrame = dispatchNamesThisFrame
+        dispatchNamesThisFrame = [:]
 
         if profiling {
             try retire(submission)
@@ -6695,6 +6913,7 @@ public final class GPUSolver {
                 appearanceOverrides ?? colliderRenderColor,
                 offset: 0, index: 13)
             enc.setBytes(&hasAppearanceOverrides, length: 4, index: 14)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (renderRigidBodyCount + 255) / 256,
                                              height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256,
@@ -6709,6 +6928,7 @@ public final class GPUSolver {
             enc.setBuffer(faceNormalsBuf, offset: 0, index: 2)
             var nt = UInt32(surfaceTriCount)
             enc.setBytes(&nt, length: 4, index: 3)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (surfaceTriCount + 255) / 256, height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
 
@@ -6728,6 +6948,7 @@ public final class GPUSolver {
             enc.setBuffer(clothVertFlag, offset: 0, index: 10)
             var cs = settings.clothRenderScale
             enc.setBytes(&cs, length: 4, index: 11)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (surfVertCount + 255) / 256, height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
         }
@@ -6739,6 +6960,7 @@ public final class GPUSolver {
             enc.setBuffer(skinVertexBuf, offset: 0, index: 2)
             var nv = UInt32(skinnedVertexCount)
             enc.setBytes(&nv, length: 4, index: 3)
+            noteDispatch("raw")
             enc.dispatchThreadgroups(MTLSize(width: (skinnedVertexCount + 255) / 256,
                                              height: 1, depth: 1),
                                      threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))

--- a/Sources/PhysicsAVBD/Shaders/20_broadphase.metal
+++ b/Sources/PhysicsAVBD/Shaders/20_broadphase.metal
@@ -154,6 +154,30 @@ kernel void bp_sort_cells(
     }
 }
 
+// Parallel form of the bucket sort above: every hashed item counts the
+// smaller ids in its bucket and scatters itself into the sorted copy. A
+// compact scene (one soft body inside a cell sized by its rigid neighbours)
+// puts hundreds of items into one bucket, where the serial insertion sort
+// ran ~0.6 ms per frame on a single thread. Same output, unique ids only.
+kernel void bp_rank_cells(
+    device const uint* hashedIdx    [[buffer(0)]],
+    device const uint2* bodyCellSlot [[buffer(1)]],
+    device const uint* cellStart    [[buffer(2)]],
+    device const uint* cellCount    [[buffer(3)]],
+    device const uint* cellBodies   [[buffer(4)]],   // scatter order
+    device uint* sortedBodies       [[buffer(5)]],
+    constant SimParams& P           [[buffer(6)]],
+    uint gid                        [[thread_position_in_grid]])
+{
+    if (gid >= P.numHashed) return;
+    uint value = hashedIdx[gid];
+    uint h = bodyCellSlot[gid].x;
+    uint s = cellStart[h], n = cellCount[h];
+    uint rank = 0;
+    for (uint k = 0; k < n; k++) rank += cellBodies[s + k] < value ? 1u : 0u;
+    sortedBodies[s + rank] = value;
+}
+
 // Binary search in sorted exclusion list of (a,b) pairs, a < b.
 inline bool pairExcluded(device const uint2* excl, uint count, uint a, uint b) {
     uint lo = 0, hi = count;

--- a/Sources/PhysicsAVBD/Shaders/40_solver.metal
+++ b/Sources/PhysicsAVBD/Shaders/40_solver.metal
@@ -131,6 +131,7 @@ kernel void adj_scatter(
     device const SoftContactGPU* soft [[buffer(9)]],
     device const MembraneGPU* membranes [[buffer(10)]],
     device const BendGPU* bends     [[buffer(11)]],
+    device uint* slotBody           [[buffer(12)]],   // owner of each slot, for adj_rank
     uint gid                        [[thread_position_in_grid]])
 {
     uint numPairs = atomic_load_explicit(&counters[CTR_PAIRS], memory_order_relaxed);
@@ -148,6 +149,7 @@ kernel void adj_scatter(
                 if (bodyDynamic(posLin, ids[k])) {
                     uint slot = atomic_fetch_add_explicit(&cursor[ids[k]], 1u, memory_order_relaxed);
                     adjList[slot] = entry;
+                    slotBody[slot] = ids[k];
                 }
             }
         } else {
@@ -158,6 +160,7 @@ kernel void adj_scatter(
                 if (bodyDynamic(posLin, ids[k])) {
                     uint slot = atomic_fetch_add_explicit(&cursor[ids[k]], 1u, memory_order_relaxed);
                     adjList[slot] = entry;
+                    slotBody[slot] = ids[k];
                 }
             }
         }
@@ -193,6 +196,7 @@ kernel void adj_scatter(
             if (bodyDynamic(posLin, v)) {
                 uint slot = atomic_fetch_add_explicit(&cursor[v], 1u, memory_order_relaxed);
                 adjList[slot] = entry;
+                slotBody[slot] = v;
             }
         }
         return;
@@ -205,6 +209,7 @@ kernel void adj_scatter(
             if (v != WORLD_BODY && bodyDynamic(posLin, v)) {
                 uint slot = atomic_fetch_add_explicit(&cursor[v], 1u, memory_order_relaxed);
                 adjList[slot] = entry;
+                slotBody[slot] = v;
             }
         }
         return;
@@ -212,10 +217,12 @@ kernel void adj_scatter(
     if (bodyDynamic(posLin, a)) {
         uint slot = atomic_fetch_add_explicit(&cursor[a], 1u, memory_order_relaxed);
         adjList[slot] = entry;
+        slotBody[slot] = a;
     }
     if (bodyDynamic(posLin, b)) {
         uint slot = atomic_fetch_add_explicit(&cursor[b], 1u, memory_order_relaxed);
         adjList[slot] = entry;
+        slotBody[slot] = b;
     }
 }
 
@@ -223,6 +230,29 @@ kernel void adj_scatter(
 // dependent summation order. Once pair/manifold indices are deterministic,
 // sorting each (typically short) CSR segment makes every primal accumulation
 // bitwise repeatable for a fixed input state.
+// Parallel form of adj_sort: one thread per filled slot ranks its entry
+// inside the owner's segment and writes the sorted copy. Entries are unique
+// per body (an element lists a body once), so ranks are a permutation.
+kernel void adj_rank(
+    device const uint* adjStart     [[buffer(0)]],
+    device const uint* adjCount     [[buffer(1)]],
+    device const uint* adjList      [[buffer(2)]],   // scatter order
+    device const uint* slotBody     [[buffer(3)]],
+    device uint* sortedList         [[buffer(4)]],
+    constant uint& numBodies        [[buffer(5)]],
+    uint gid                        [[thread_position_in_grid]])
+{
+    if (numBodies == 0) return;
+    uint total = adjStart[numBodies - 1] + adjCount[numBodies - 1];
+    if (gid >= total) return;
+    uint b = slotBody[gid];
+    uint s = adjStart[b], n = adjCount[b];
+    uint value = adjList[gid];
+    uint rank = 0;
+    for (uint k = 0; k < n; k++) rank += adjList[s + k] < value ? 1u : 0u;
+    sortedList[s + rank] = value;
+}
+
 kernel void adj_sort(
     device const uint* adjStart     [[buffer(0)]],
     device const uint* adjCount     [[buffer(1)]],
@@ -2072,8 +2102,8 @@ kernel void primal_solve_torsion(
 // the group reduces the system via simd_shuffle_xor, and lane 0 solves.
 // Per-body serial stamping (~20-30 scattered gathers) left contact-rich
 // dispatches latency-bound; cooperative stamping exposes those gathers.
-template <uint splitShift, uint splitWidth>
-static inline void primal_split_impl(
+template <uint splitWidth>
+static inline void primal_split_body_impl(
     device float4* posLin,
     device float4* posAng,
     device const float4* initLin,
@@ -2087,9 +2117,6 @@ static inline void primal_split_impl(
     device const uint* adjStart,
     device const uint* adjCount,
     device const uint* adjList,
-    device const uint* colorList,
-    device const uint* colorStart,
-    constant uint& colorIndex,
     constant SimParams& P,
     device const float4* shape,
     device const TetGPU* tets,
@@ -2102,14 +2129,8 @@ static inline void primal_split_impl(
     device const SolverManifoldGPU* solveManifolds,
     device const SolverContactGPU* solveContacts,
     constant uint& useCompactManifolds,
-    uint tid)
+    uint body, uint lane)
 {
-    uint s = colorStart[colorIndex];
-    uint e = colorStart[colorIndex + 1];
-    uint slot = tid >> splitShift;
-    uint lane = tid & (splitWidth - 1u);
-    if (s + slot >= e) return;       // uniform across the cooperative group
-    uint body = colorList[s + slot];
     // Rigids stamp cooperatively too: a box resting on high-res cloth
     // gathers THOUSANDS of contacts (rt corner-tri + particle np) in its
     // adjacency — serialized on one lane it gated the whole dispatch
@@ -2223,44 +2244,82 @@ static inline void primal_split_impl(
     if (rigid) posAng[body] = q_addw(posAng[body], dxAng);
 }
 
-// Fused torsion specialization of the cooperative primal. Its dispatch and
-// reduction topology exactly match `primal_particles_split`; the only added
-// work is one rank-1 angular stamp when a lane owns a manifold adjacency.
-kernel void primal_particles_split_torsion(
-    device float4* posLin           [[buffer(0)]],
-    device float4* posAng           [[buffer(1)]],
-    device const float4* initLin    [[buffer(2)]],
-    device const float4* initAng    [[buffer(3)]],
-    device const float4* inertLin   [[buffer(4)]],
-    device const float4* inertAng   [[buffer(5)]],
-    device const float4* props      [[buffer(6)]],
-    device const JointGPU* joints   [[buffer(7)]],
-    device const SpringGPU* springs [[buffer(8)]],
-    device const ManifoldGPU* manifolds [[buffer(9)]],
-    device const uint* adjStart     [[buffer(10)]],
-    device const uint* adjCount     [[buffer(11)]],
-    device const uint* adjList      [[buffer(12)]],
-    device const uint* colorList    [[buffer(13)]],
-    device const uint* colorStart   [[buffer(14)]],
-    constant uint& colorIndex       [[buffer(15)]],
-    constant SimParams& P           [[buffer(16)]],
-    device const float4* shape      [[buffer(17)]],
-    device const TetGPU* tets       [[buffer(18)]],
-    device const SoftContactGPU* soft [[buffer(19)]],
-    device const MembraneGPU* membranes [[buffer(20)]],
-    device const BendGPU* bends     [[buffer(21)]],
-    device const uint* boundsBits   [[buffer(22)]],
-    device const float4* ogcPrev    [[buffer(23)]],
-    device atomic_uint* ogcCounters [[buffer(24)]],
-    device const float4* torsionState [[buffer(25)]],
-    uint tid                        [[thread_position_in_grid]])
+template <uint splitShift, uint splitWidth>
+static inline void primal_split_impl(
+    device float4* posLin,
+    device float4* posAng,
+    device const float4* initLin,
+    device const float4* initAng,
+    device const float4* inertLin,
+    device const float4* inertAng,
+    device const float4* props,
+    device const JointGPU* joints,
+    device const SpringGPU* springs,
+    device const ManifoldGPU* manifolds,
+    device const uint* adjStart,
+    device const uint* adjCount,
+    device const uint* adjList,
+    device const uint* colorList,
+    device const uint* colorStart,
+    constant uint& colorIndex,
+    constant SimParams& P,
+    device const float4* shape,
+    device const TetGPU* tets,
+    device const SoftContactGPU* soft,
+    device const MembraneGPU* membranes,
+    device const BendGPU* bends,
+    device const uint* boundsBits,
+    device const float4* ogcPrev,
+    device atomic_uint* ogcCounters,
+    device const SolverManifoldGPU* solveManifolds,
+    device const SolverContactGPU* solveContacts,
+    constant uint& useCompactManifolds,
+    uint tid)
 {
     uint s = colorStart[colorIndex];
     uint e = colorStart[colorIndex + 1];
-    uint slot = tid >> 3;
-    uint lane = tid & 7u;
-    if (s + slot >= e) return;
-    uint body = colorList[s + slot];
+    uint slot = tid >> splitShift;
+    uint lane = tid & (splitWidth - 1u);
+    if (s + slot >= e) return;       // uniform across the cooperative group
+    primal_split_body_impl<splitWidth>(
+        posLin, posAng, initLin, initAng, inertLin, inertAng, props,
+        joints, springs, manifolds, adjStart, adjCount, adjList, P, shape,
+        tets, soft, membranes, bends, boundsBits, ogcPrev, ogcCounters,
+        solveManifolds, solveContacts, useCompactManifolds,
+        colorList[s + slot], lane);
+}
+
+// Fused torsion specialization of the cooperative primal. Its dispatch and
+// reduction topology exactly match `primal_particles_split`; the only added
+// work is one rank-1 angular stamp when a lane owns a manifold adjacency.
+// Body-level torsion primal shared by the per-colour dispatch and the
+// single-threadgroup colour tail (see primal_particles_split_torsion_tail).
+static inline void primal_split_torsion_body(
+    device float4* posLin,
+    device float4* posAng,
+    device const float4* initLin,
+    device const float4* initAng,
+    device const float4* inertLin,
+    device const float4* inertAng,
+    device const float4* props,
+    device const JointGPU* joints,
+    device const SpringGPU* springs,
+    device const ManifoldGPU* manifolds,
+    device const uint* adjStart,
+    device const uint* adjCount,
+    device const uint* adjList,
+    constant SimParams& P,
+    device const float4* shape,
+    device const TetGPU* tets,
+    device const SoftContactGPU* soft,
+    device const MembraneGPU* membranes,
+    device const BendGPU* bends,
+    device const uint* boundsBits,
+    device const float4* ogcPrev,
+    device atomic_uint* ogcCounters,
+    device const float4* torsionState,
+    uint body, uint lane)
+{
     bool rigid = shape[body].w >= 0.0f;
 
     PrimalAccum acc;
@@ -2370,6 +2429,104 @@ kernel void primal_particles_split_torsion(
     if (rigid) posAng[body] = q_addw(posAng[body], dxAng);
 }
 
+kernel void primal_particles_split_torsion(
+    device float4* posLin           [[buffer(0)]],
+    device float4* posAng           [[buffer(1)]],
+    device const float4* initLin    [[buffer(2)]],
+    device const float4* initAng    [[buffer(3)]],
+    device const float4* inertLin   [[buffer(4)]],
+    device const float4* inertAng   [[buffer(5)]],
+    device const float4* props      [[buffer(6)]],
+    device const JointGPU* joints   [[buffer(7)]],
+    device const SpringGPU* springs [[buffer(8)]],
+    device const ManifoldGPU* manifolds [[buffer(9)]],
+    device const uint* adjStart     [[buffer(10)]],
+    device const uint* adjCount     [[buffer(11)]],
+    device const uint* adjList      [[buffer(12)]],
+    device const uint* colorList    [[buffer(13)]],
+    device const uint* colorStart   [[buffer(14)]],
+    constant uint& colorIndex       [[buffer(15)]],
+    constant SimParams& P           [[buffer(16)]],
+    device const float4* shape      [[buffer(17)]],
+    device const TetGPU* tets       [[buffer(18)]],
+    device const SoftContactGPU* soft [[buffer(19)]],
+    device const MembraneGPU* membranes [[buffer(20)]],
+    device const BendGPU* bends     [[buffer(21)]],
+    device const uint* boundsBits   [[buffer(22)]],
+    device const float4* ogcPrev    [[buffer(23)]],
+    device atomic_uint* ogcCounters [[buffer(24)]],
+    device const float4* torsionState [[buffer(25)]],
+    uint tid                        [[thread_position_in_grid]])
+{
+    uint s = colorStart[colorIndex];
+    uint e = colorStart[colorIndex + 1];
+    uint slot = tid >> 3;
+    uint lane = tid & 7u;
+    if (s + slot >= e) return;
+    primal_split_torsion_body(
+        posLin, posAng, initLin, initAng, inertLin, inertAng, props,
+        joints, springs, manifolds, adjStart, adjCount, adjList, P, shape,
+        tets, soft, membranes, bends, boundsBits, ogcPrev, ogcCounters,
+        torsionState, colorList[s + slot], lane);
+}
+
+// Colour tail: the CPU bounds the per-colour dispatch loop by last frame's
+// palette size plus a margin (a stale readback under pipelining is fine,
+// the bound only affects speed). Colours at or beyond that bound are solved
+// here, exactly as the per-colour dispatches would: one threadgroup walks
+// the remaining colours in order, and inside a colour bodies are
+// independent, so waves of threadgroup-size / 8 bodies separated by a
+// device-memory barrier reproduce the dispatched result bit for bit.
+kernel void primal_particles_split_torsion_tail(
+    device float4* posLin           [[buffer(0)]],
+    device float4* posAng           [[buffer(1)]],
+    device const float4* initLin    [[buffer(2)]],
+    device const float4* initAng    [[buffer(3)]],
+    device const float4* inertLin   [[buffer(4)]],
+    device const float4* inertAng   [[buffer(5)]],
+    device const float4* props      [[buffer(6)]],
+    device const JointGPU* joints   [[buffer(7)]],
+    device const SpringGPU* springs [[buffer(8)]],
+    device const ManifoldGPU* manifolds [[buffer(9)]],
+    device const uint* adjStart     [[buffer(10)]],
+    device const uint* adjCount     [[buffer(11)]],
+    device const uint* adjList      [[buffer(12)]],
+    device const uint* colorList    [[buffer(13)]],
+    device const uint* colorStart   [[buffer(14)]],
+    constant uint& firstColor       [[buffer(15)]],
+    constant SimParams& P           [[buffer(16)]],
+    device const float4* shape      [[buffer(17)]],
+    device const TetGPU* tets       [[buffer(18)]],
+    device const SoftContactGPU* soft [[buffer(19)]],
+    device const MembraneGPU* membranes [[buffer(20)]],
+    device const BendGPU* bends     [[buffer(21)]],
+    device const uint* boundsBits   [[buffer(22)]],
+    device const float4* ogcPrev    [[buffer(23)]],
+    device atomic_uint* ogcCounters [[buffer(24)]],
+    device const float4* torsionState [[buffer(25)]],
+    uint ltid                       [[thread_index_in_threadgroup]],
+    uint tgSize                     [[threads_per_threadgroup]])
+{
+    uint used = colorStart[MAX_COLORS + 1];
+    uint slots = tgSize >> 3;
+    uint lane = ltid & 7u;
+    for (uint c = firstColor; c < used; c++) {
+        uint s = colorStart[c];
+        uint e = colorStart[c + 1];
+        for (uint base = s; base < e; base += slots) {
+            uint slot = base + (ltid >> 3);
+            if (slot < e) {
+                primal_split_torsion_body(
+                posLin, posAng, initLin, initAng, inertLin, inertAng, props,
+                joints, springs, manifolds, adjStart, adjCount, adjList, P, shape,
+                tets, soft, membranes, bends, boundsBits, ogcPrev, ogcCounters,
+                torsionState, colorList[slot], lane);
+            }
+            threadgroup_barrier(mem_flags::mem_device);
+        }
+    }
+}
+
 #define PRIMAL_SPLIT_KERNEL_ARGS \
     device float4* posLin [[buffer(0)]], \
     device float4* posAng [[buffer(1)]], \
@@ -2418,6 +2575,73 @@ kernel void primal_rigid_split(PRIMAL_SPLIT_KERNEL_ARGS)
 {
     CALL_PRIMAL_SPLIT(4u, 16u);
 }
+
+#define PRIMAL_SPLIT_TAIL_KERNEL_ARGS \
+    device float4* posLin [[buffer(0)]], \
+    device float4* posAng [[buffer(1)]], \
+    device const float4* initLin [[buffer(2)]], \
+    device const float4* initAng [[buffer(3)]], \
+    device const float4* inertLin [[buffer(4)]], \
+    device const float4* inertAng [[buffer(5)]], \
+    device const float4* props [[buffer(6)]], \
+    device const JointGPU* joints [[buffer(7)]], \
+    device const SpringGPU* springs [[buffer(8)]], \
+    device const ManifoldGPU* manifolds [[buffer(9)]], \
+    device const uint* adjStart [[buffer(10)]], \
+    device const uint* adjCount [[buffer(11)]], \
+    device const uint* adjList [[buffer(12)]], \
+    device const uint* colorList [[buffer(13)]], \
+    device const uint* colorStart [[buffer(14)]], \
+    constant uint& firstColor [[buffer(15)]], \
+    constant SimParams& P [[buffer(16)]], \
+    device const float4* shape [[buffer(17)]], \
+    device const TetGPU* tets [[buffer(18)]], \
+    device const SoftContactGPU* soft [[buffer(19)]], \
+    device const MembraneGPU* membranes [[buffer(20)]], \
+    device const BendGPU* bends [[buffer(21)]], \
+    device const uint* boundsBits [[buffer(22)]], \
+    device const float4* ogcPrev [[buffer(23)]], \
+    device atomic_uint* ogcCounters [[buffer(24)]], \
+    device const SolverManifoldGPU* solveManifolds [[buffer(25)]], \
+    device const SolverContactGPU* solveContacts [[buffer(26)]], \
+    constant uint& useCompactManifolds [[buffer(27)]], \
+    uint ltid [[thread_index_in_threadgroup]], \
+    uint tgSize [[threads_per_threadgroup]]
+
+// Colour tail for the lane-split kernels; see primal_particles_split_torsion_tail.
+#define PRIMAL_SPLIT_TAIL(SHIFT, WIDTH) \
+    uint used = colorStart[MAX_COLORS + 1]; \
+    uint slots = tgSize >> SHIFT; \
+    uint lane = ltid & (WIDTH - 1u); \
+    for (uint c = firstColor; c < used; c++) { \
+        uint s = colorStart[c]; \
+        uint e = colorStart[c + 1]; \
+        for (uint base = s; base < e; base += slots) { \
+            uint slot = base + (ltid >> SHIFT); \
+            if (slot < e) { \
+                primal_split_body_impl<WIDTH>( \
+                    posLin, posAng, initLin, initAng, inertLin, inertAng, \
+                    props, joints, springs, manifolds, adjStart, adjCount, \
+                    adjList, P, shape, tets, soft, membranes, bends, \
+                    boundsBits, ogcPrev, ogcCounters, solveManifolds, \
+                    solveContacts, useCompactManifolds, colorList[slot], \
+                    lane); \
+            } \
+            threadgroup_barrier(mem_flags::mem_device); \
+        } \
+    }
+
+kernel void primal_particles_split_tail(PRIMAL_SPLIT_TAIL_KERNEL_ARGS)
+{
+    PRIMAL_SPLIT_TAIL(3u, 8u);
+}
+
+kernel void primal_rigid_split_tail(PRIMAL_SPLIT_TAIL_KERNEL_ARGS)
+{
+    PRIMAL_SPLIT_TAIL(4u, 16u);
+}
+#undef PRIMAL_SPLIT_TAIL
+#undef PRIMAL_SPLIT_TAIL_KERNEL_ARGS
 
 #undef CALL_PRIMAL_SPLIT
 #undef PRIMAL_SPLIT_KERNEL_ARGS

--- a/Tests/PhysicsAVBDTests/GPUSolverTests.swift
+++ b/Tests/PhysicsAVBDTests/GPUSolverTests.swift
@@ -852,6 +852,131 @@ final class GPUSolverTests: XCTestCase {
     /// reproducible as rigid manifolds. Their emission is parallel, so the
     /// solver has to assign contact indices and element candidate order by
     /// content rather than by which thread won an atomic append.
+    /// The bounded colour loop plus the colour-tail dispatch must reproduce
+    /// the fully dispatched loop bit for bit: run one solver with a margin
+    /// that never engages the tail and one that pushes every colour into it.
+    private func assertBitwiseEqualStates(
+        _ a: GPUSolver, _ b: GPUSolver, bodies: [Int], _ label: String,
+        file: StaticString = #filePath, line: UInt = #line) {
+        let sa = a.bodyStates(bodies)
+        let sb = b.bodyStates(bodies)
+        var mismatches = 0
+        for i in sa.indices where sa[i].position.x.bitPattern
+            != sb[i].position.x.bitPattern
+            || sa[i].position.y.bitPattern != sb[i].position.y.bitPattern
+            || sa[i].position.z.bitPattern != sb[i].position.z.bitPattern
+            || sa[i].linearVelocity.x.bitPattern
+                != sb[i].linearVelocity.x.bitPattern
+            || sa[i].rotation.real.bitPattern
+                != sb[i].rotation.real.bitPattern {
+            mismatches += 1
+        }
+        XCTAssertEqual(mismatches, 0,
+            "\(label): \(mismatches) of \(bodies.count) bodies differ",
+            file: file, line: line)
+    }
+
+    /// The parallel rank sorts (bp_rank_cells, adj_rank) replace serial
+    /// per-bucket insertion sorts; the sorted streams must be identical, so
+    /// the trajectories must match bit for bit.
+    func testParallelRankSortsMatchSerialSorts() throws {
+        var cloth = Demos.cloth(res: 12, ball: true)
+        cloth.settings.deterministic = true
+        var pile = Demos.boxpile(count: 60)
+        pile.settings.deterministic = true
+        for (label, scene) in [("cloth", cloth), ("boxpile", pile)] {
+            let bodies = Array(0..<scene.bodies.count)
+            let parallel = try makeGPU(scene)
+            let serial = try makeGPU(scene)
+            serial.legacySerialSortsForTesting = true
+            for _ in 0..<120 {
+                parallel.step()
+                serial.step()
+            }
+            parallel.sync()
+            serial.sync()
+            XCTAssertNil(parallel.runtimeFailure, label)
+            assertBitwiseEqualStates(parallel, serial, bodies: bodies, label)
+        }
+    }
+
+    /// A single tet solid without cloth vertices never emits a V-T or E-E
+    /// contact (the kernels drop every same-solid candidate), so skipping the
+    /// element grid and both emitters must leave the trajectory untouched.
+    func testSurfaceEmissionSkipIsExactForSingleSolid() throws {
+        var scene = Demos.softbody()
+        scene.settings.deterministic = true
+        let bodies = Array(0..<scene.bodies.count)
+        let skipping = try makeGPU(scene)
+        let emitting = try makeGPU(scene)
+        emitting.forceSurfaceEmissionForTesting = true
+        for s in [skipping, emitting] { s.surfaceTruncationMode = .isotropicDAT }
+        XCTAssertGreaterThan(skipping.numTris, 0, "fixture needs boundary faces")
+        for _ in 0..<120 {
+            skipping.step()
+            emitting.step()
+        }
+        skipping.sync()
+        emitting.sync()
+        XCTAssertNil(skipping.runtimeFailure)
+        XCTAssertLessThan(skipping.dispatchesLastFrame,
+                          emitting.dispatchesLastFrame,
+                          "the skip must remove dispatches")
+        assertBitwiseEqualStates(skipping, emitting, bodies: bodies, "softbody")
+    }
+
+    func testDynamicColorTailIsBitwiseExact() throws {
+        for (label, torsion) in [("plain", false), ("torsion", true)] {
+            var scene = Demos.cloth(res: 12, ball: true)
+            scene.settings.deterministic = true
+            if torsion {
+                for i in scene.colliders.indices {
+                    scene.colliders[i].torsionalFriction = 0.02
+                }
+            }
+            let bodies = Array(0..<scene.bodies.count)
+            let loop = try makeGPU(scene)
+            let tail = try makeGPU(scene)
+            loop.surfaceTruncationMode = .isotropicDAT
+            tail.surfaceTruncationMode = .isotropicDAT
+            loop.colorBoundMarginForTesting = AVBD_MAX_COLORS
+            tail.colorBoundMarginForTesting = -AVBD_MAX_COLORS
+            var tailDispatches = 0
+            tail.solveDispatchObserverForTesting = {
+                if case .primalTail = $0 { tailDispatches += 1 }
+            }
+            for _ in 0..<120 {
+                loop.step()
+                tail.step()
+            }
+            loop.sync()
+            tail.sync()
+            XCTAssertNil(tail.runtimeFailure, label)
+            XCTAssertEqual(loop.lastColorTailColors, 0, label)
+            XCTAssertEqual(tail.lastColorTailColors,
+                           tail.lastMaxColorUsed + 1, label)
+            XCTAssertGreaterThan(tailDispatches, 0, label)
+            XCTAssertGreaterThan(tail.lastNumSoft, 0, label)
+            let a = loop.bodyStates(bodies)
+            let b = tail.bodyStates(bodies)
+            var mismatches = 0
+            for i in a.indices where a[i].position.x.bitPattern
+                != b[i].position.x.bitPattern
+                || a[i].position.y.bitPattern != b[i].position.y.bitPattern
+                || a[i].position.z.bitPattern != b[i].position.z.bitPattern
+                || a[i].linearVelocity.x.bitPattern
+                    != b[i].linearVelocity.x.bitPattern
+                || a[i].rotation.real.bitPattern
+                    != b[i].rotation.real.bitPattern {
+                mismatches += 1
+            }
+            XCTAssertEqual(mismatches, 0,
+                "\(label): \(mismatches) of \(bodies.count) bodies differ "
+                    + "between the dispatched loop and the colour tail "
+                    + "(colours \(tail.lastMaxColorUsed + 1))")
+        }
+    }
+
     func testDeformableContactTrajectoryIsBitwiseDeterministic() throws {
         // res 12 stays under the 1024-body ordered-coloring limit; res 34
         // exceeds it and exercises the compact multi-slot neighbor stream.
@@ -897,6 +1022,7 @@ final class GPUSolverTests: XCTestCase {
                     + "between two identical solvers")
         }
     }
+
 
     func testContactRichTrajectoryIsBitwiseDeterministic() throws {
         var scene = PhysicsScene(name: "deterministic-contact-grid")


### PR DESCRIPTION
Stacked on #18. Cuts the per-substep GPU time of a small mixed scene (one tet soft body inside an articulated robot, 285 bodies) from 3.3 ms to 1.3 ms with static colouring, and removes ~1000 empty dispatches per frame under the deterministic dynamic colouring. Every change is bitwise exact against the previous path and covered by a two-solver comparison test.

## What was slow
The hash-grid cell is sized by the largest hashed collider (10 cm here), so a compact soft body lands in one bucket. Two kernels then ran serially on a single thread per bucket: `bp_sort_cells` (0.63 ms) and `adj_sort` (0.08 ms). `vt_emit` scanned every element for every particle (0.44 ms) only to drop each candidate as same-solid. With `deterministic = true` the primal loop dispatched all 64 colour slots per iteration, ~1000 empty dispatches per frame.

## Changes
- **`bp_rank_cells` / `adj_rank`**: parallel rank sorts producing the identical sorted streams; the serial kernels stay reachable through `legacySerialSortsForTesting`.
- **`surfaceEmissionNeeded`**: skips the element grid and the V-T/E-E emitters when the surface elements all belong to one solid without cloth vertices (the kernels' own `sameSolid_` gate proves nothing could be emitted). Rigid-vs-triangle emission still runs.
- **Colour tail**: the dynamic-colouring loop is bounded by the last palette readback plus a margin of 8; one single-threadgroup dispatch (`primal_*_split_tail`) solves any colours beyond the bound with the same body-level code as the lane-split kernels, so a stale bound under pipelining changes only where the work runs. Planar-DAT and `primal_solve` keep the full loop.
- Diagnostics: `dispatchesLastFrame`, `dispatchNamesLastFrame`, `debugSceneCounts`, per-kernel sub-stages in profiling mode.

## Tests
- `testParallelRankSortsMatchSerialSorts` (cloth + boxpile), `testSurfaceEmissionSkipIsExactForSingleSolid` (softbody), `testDynamicColorTailIsBitwiseExact` (plain + torsional friction, every colour forced through the tail).
- Full suite: 288 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
