### PR TITLE
Preserve thin convex hull extrema during construction

### DIFF
--- a/Sources/PhysicsAVBD/ConvexHullTopology.swift
+++ b/Sources/PhysicsAVBD/ConvexHullTopology.swift
@@ -282,15 +282,33 @@ enum ConvexHullTopologyBuilder {
                 throw Failure(reason: "generated hull horizon is disconnected")
             }
 
+            let replacements = horizon.map { edge in
+                orientedFace(edge.1, edge.0, pointIndex,
+                             points: points, interior: interior)
+            }
+            // Adjacent Float extrema can cut a nanometre-sized sliver off
+            // an otherwise valid face. The GPU clipping topology rejects
+            // cross lengths <= 1e-12, including after Float centering. Keep
+            // the existing boundary only when it already contains this
+            // sample within the public validation envelope. Final full-
+            // cloud containment and manifold checks still apply below.
+            let createsSliver = replacements.contains { face in
+                let a = SIMD3<Float>(points[face.a].value)
+                let b = SIMD3<Float>(points[face.b].value)
+                let c = SIMD3<Float>(points[face.c].value)
+                return simd_length(simd_cross(b - a, c - a)) <= 1e-12
+            }
+            if createsSliver && faces.allSatisfy({ face in
+                let n = normal(face, points: points)
+                return dot(n, points[pointIndex].value - points[face.a].value)
+                    <= tolerance * sqrt(lengthSquared(n))
+            }) { continue }
+
             let visibleSet = Set(visible)
             faces = faces.enumerated().compactMap {
                 visibleSet.contains($0.offset) ? nil : $0.element
             }
-            for edge in horizon {
-                faces.append(orientedFace(
-                    edge.1, edge.0, pointIndex,
-                    points: points, interior: interior))
-            }
+            faces.append(contentsOf: replacements)
         }
 
         guard faces.count >= 4,

--- a/Sources/PhysicsAVBD/ConvexHullTopology.swift
+++ b/Sources/PhysicsAVBD/ConvexHullTopology.swift
@@ -140,6 +140,13 @@ enum ConvexHullTopologyBuilder {
             throw Failure(reason: "does not span a finite three-dimensional hull")
         }
         let tolerance = max(diagonal * 1.0e-7, 1.0e-9)
+        // Construction operates in Double. A point within the Float-sized
+        // validation envelope of an early face can lie outside a later face
+        // after the horizon changes. Skipping it with that same envelope can
+        // therefore produce a hull that fails its own containment check.
+        // Retain those near-coplanar extremes during construction, while
+        // leaving the public geometry-validation tolerance unchanged.
+        let visibilityTolerance = max(diagonal * 1.0e-12, 1.0e-15)
 
         // Deterministic maximal selections use lexicographic order as the
         // tie-breaker (the points array is already sorted ascending).
@@ -215,7 +222,7 @@ enum ConvexHullTopologyBuilder {
                 }
                 let distance = dot(faceNormal,
                     points[pointIndex].value - points[face.a].value)
-                if distance > tolerance * normalLength {
+                if distance > visibilityTolerance * normalLength {
                     visible.append(faceIndex)
                 }
             }

--- a/Tests/PhysicsAVBDTests/ThinConvexHullTests.swift
+++ b/Tests/PhysicsAVBDTests/ThinConvexHullTests.swift
@@ -46,4 +46,27 @@ final class ThinConvexHullTests: XCTestCase {
         try gpu.synchronize()
         XCTAssertTrue(gpu.bodyPosition(body).z.isFinite)
     }
+
+    func testAdjacentFloatExtremaDoNotEmitSubthresholdSlivers() throws {
+        var scene = PhysicsScene(name: "near-coincident Float extrema")
+        for i in 1...8 {
+            let r: Float = 0.001 * Float(i)
+            var vertices = [-1, 1].flatMap { x in [-1, 1].flatMap { y in [-1, 1].map { z in
+                F3(Float(x) * r, Float(y) * r, Float(z) * 0.01)
+            } } }
+            vertices += [F3(r.nextDown, r.nextUp, 0.01), F3(r.nextUp, r.nextDown, 0.01),
+                         F3(r, r, Float(0.01).nextUp)]
+            let triangles = try ConvexHullTopologyBuilder.triangulate(vertices: vertices)
+            for t in triangles {
+                let crossLength = length(cross(vertices[Int(t.y)] - vertices[Int(t.x)],
+                                               vertices[Int(t.z)] - vertices[Int(t.x)]))
+                XCTAssertGreaterThan(crossLength, 1e-12, "case \(i) must meet the GPU topology threshold")
+            }
+            let body = scene.addBody(size: F3(repeating: 0.1), density: 100,
+                friction: 0.5, position: F3(Float(i), 0, 1), collisionEnabled: false)
+            scene.addConvexCollider(body: body, vertices: vertices, collisionEnabled: true, isRendered: false)
+        }
+        let gpu = try GPUSolver(scene: scene)
+        try gpu.submitStep(); try gpu.synchronize()
+    }
 }

--- a/Tests/PhysicsAVBDTests/ThinConvexHullTests.swift
+++ b/Tests/PhysicsAVBDTests/ThinConvexHullTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import simd
+@testable import PhysicsAVBD
+@testable import SimCore
+
+final class ThinConvexHullTests: XCTestCase {
+    // A real generated plate-wall sector: a thin annulus above a solid foot.
+    // Float construction makes some nominally coplanar vertices differ by a
+    // few nanometres. The support cloud is still a valid solid convex set.
+    private let sector: [F3] = [
+        F3(0, 0, -0.008243507),
+        F3(-0.038563777, 0.022264821, -0.008243507),
+        F3(-0.04452962, -3.892903e-9, -0.008243507),
+        F3(-0.07023556, 0.040550545, 0.008243507),
+        F3(-0.08110105, -7.090079e-9, 0.008243507),
+        F3(-0.07369966, 0.042550545, 0.008243507),
+        F3(-0.08510105, -7.43977e-9, 0.008243507),
+    ]
+
+    func testThinRadialSectorBuildsAfterCenteringRotationAndScaling() throws {
+        for scale: Float in [0.1, 1, 10] {
+            for step in 0..<24 {
+                let q = Quat(angle: Float(step) * .pi / 12, axis: normalize(F3(1, 2, 3)))
+                let source = sector.map { q.act($0 * scale) }
+                let lower = source.reduce(F3(repeating: .infinity), simd_min)
+                let upper = source.reduce(F3(repeating: -.infinity), simd_max)
+                let vertices = source.map { $0 - (lower + upper) * 0.5 }
+                do {
+                    let faces = try ConvexHullTopologyBuilder.triangulate(vertices: vertices)
+                    XCTAssertGreaterThanOrEqual(faces.count, 4)
+                    XCTAssertEqual(faces, try ConvexHullTopologyBuilder.triangulate(vertices: vertices))
+                } catch {
+                    XCTFail("scale \(scale), rotation \(step): \(error)")
+                }
+            }
+        }
+    }
+
+    func testThinSectorCanBeUploadedAsAnInlineCollider() throws {
+        var scene = PhysicsScene(name: "thin generated plate sector")
+        let body = scene.addBody(size: F3(repeating: 0.1), density: 100,
+                                 friction: 0.5, position: F3(0, 0, 1), collisionEnabled: false)
+        scene.addConvexCollider(body: body, vertices: sector, collisionEnabled: true, isRendered: false)
+        let gpu = try GPUSolver(scene: scene)
+        try gpu.submitStep()
+        try gpu.synchronize()
+        XCTAssertTrue(gpu.bodyPosition(body).z.isFinite)
+    }
+}


### PR DESCRIPTION
Generated thin vessel-wall sectors can fail GPU construction with `generated face ... does not contain every support point`, even though the input support cloud describes a valid solid hull. The incremental builder used the same Float-scale tolerance for deciding whether to retain a point and for validating the final hull. A point discarded near an early face can be outside a later face after the horizon changes.

Use Double-scale precision for face visibility during construction, retaining near-coplanar extremes. Keep the existing input, degeneracy, containment, manifold, and volume validation checks unchanged. Cooked assets and their topology are unaffected.

Validation:

- A seven-vertex sector from the dishwasher generator reproduced the failure before the fix, including 50 of 72 centered/rotated/scaled variants and GPU upload.
- All 72 variants and the GPU upload/step regression pass afterward.
- 64 convex collision/topology tests and 66 selected GPU solver/renderer tests pass, including the two new tests in both groups.

Dependency for the generated dishwasher scenarios in LuckyIYI/teleopkit, stacked on its existing dishwasher showcase.
