### PR TITLE
Accelerate compound broadphase with bounded subtrees and cached pairs

### DIFF
--- a/Documentation/CompoundBroadphasePerformance.md
+++ b/Documentation/CompoundBroadphasePerformance.md
@@ -8,7 +8,7 @@ Large rigid compounds now expose disjoint BVH subtrees of at most 16 leaves to t
 
 The count pass records accepted pairs as one-byte proxy-local leaf indices in traversal order. Emit copies these cached pairs after the exclusive scan; it no longer repeats transforms, sphere tests, or the tree walk. The leaf-node sphere already equals the previous collider sphere predicate, including hull padding, so the redundant second leaf test is removed.
 
-The hierarchy count/scan capacity is bounded by `min(maxPairs, proxyCount * (proxyCount - 1) / 2)` (with a one-entry empty-case allocation). Emit dispatches only the live proxy pairs. Explicit encoder boundaries protect scratch-buffer reuse and GPU-written indirect arguments during unprofiled execution.
+The hierarchy expansion count/scan capacity is bounded by `min(maxPairs, proxyCount * (proxyCount - 1) / 2)` (with a one-entry empty-case allocation). The proxy-pair buffer uses that bound, and the shared count/start buffers reserve the larger of that bound and the grid producer count. Emit dispatches only the live proxy pairs. Explicit encoder boundaries protect scratch-buffer reuse and GPU-written indirect arguments during unprofiled execution.
 
 ## Dishwasher results
 
@@ -27,7 +27,7 @@ GPU totals sum the existing encoder timestamp measurements. They are instrumente
 
 ## Validation
 
-40 Metal GPU tests passed: the full `ConvexGPURuntimeTests` suite, contact-rich trajectory determinism, exact pair capacity, and overflow rejection. New checks cover:
+43 Metal GPU tests passed with Metal API and shader validation enabled: the full `ConvexGPURuntimeTests` suite, contact-rich trajectory determinism, exact pair capacity, and overflow rejection. New checks cover:
 
 - Complete pair-set equality against a brute-force sphere oracle for mixed, rotated, uneven compounds with collision domains, shared geometry, and owner exclusions.
 - Disjoint, complete leaf coverage and the maximum subtree size.
@@ -36,7 +36,7 @@ GPU totals sum the existing encoder timestamp measurements. They are instrumente
 - A populated frame followed by an empty frame and contacts returning, with both unprofiled and profiled dispatch paths.
 
 ```sh
-swift test --filter 'ConvexGPURuntimeTests|GPUSolverTests.testExactRigidPairCapacity|GPUSolverTests.testRigidPairOverflow|GPUSolverTests.testContactRichTrajectory'
+MTL_DEBUG_LAYER=1 MTL_SHADER_VALIDATION=1 swift test -c release --filter 'ConvexGPURuntimeTests|GPUSolverTests.testExactRigidPairCapacity|GPUSolverTests.testRigidPairOverflow|GPUSolverTests.testContactRichTrajectory'
 ```
 
 Tests must run with Metal access; a sandbox that hides the GPU skips the Metal cases. Local raw profiles, the benchmark Swift source, machine-readable summary, and test log are under `artifacts/compound-broadphase/` (ignored generated artifacts).
@@ -46,3 +46,25 @@ Tests must run with Metal access; a sandbox that hides the GPU skips the Metal c
 The optimization applies to rigid compound scenes generally. Analytic scenes without compounds and deformable collision paths keep their existing broad phase. It uses the existing conservative sphere bounds and hull padding; tighter geometric bounds remain a separate improvement. More proxies can increase grid pair-generation work, which is included in the GPU totals above. The compact cache requires up to 256 bytes per reserved hierarchy proxy-pair entry, capped by the existing output pair capacity, plus 64 bytes per proxy.
 
 The TeleopKit app remains pinned to the baseline revision; these results use a separate headless harness linked to the optimization worktree.
+
+## PR review follow-up
+
+The initial change bounded scan work but left the proxy-pair and count/start
+allocations at contact-output capacity. The review fix applies the same
+proven proxy-pair bound to those buffers, retaining the grid-producer bound
+for shared scan scratch. For seed 0 this removes 1,311,232 reserved bytes
+from those three buffers without changing dispatches or pair order. This is
+a storage calculation, not an additional measured timing claim.
+
+Added tests exercise one/two/five-proxy scratch bounds and raw proxy overflow
+(4,950 eligible proxy pairs against 4,096 entries), in addition to the existing
+leaf-output overflow, full cache tiles and empty-frame checks.
+
+The review also found a correctness issue in the new finalizer: `dispatch1D`
+launches a full threadgroup, but every invocation read and replaced the same
+proxy-count counter. A later invocation could interpret the published leaf
+count as a proxy count. The finalizer now explicitly permits only global
+thread zero to write. An integration run exposed a zero-contact first frame
+(0 instead of 256) with tighter scratch; a scheduling stress test covers the
+finalizer alongside the full-tile regression. Race manifestation is schedule
+dependent; the original allocation layout passed a separate 41-test run.

--- a/Documentation/CompoundBroadphasePerformance.md
+++ b/Documentation/CompoundBroadphasePerformance.md
@@ -1,0 +1,48 @@
+# Compound broadphase performance
+
+Measured on 2026-09-05, Apple M5 (10 GPU cores), release Swift build. Baseline: `d4b687ac1e38b8f4480fe25b737912c1d07bf8a1`, the revision pinned by the TeleopKit dishwasher app.
+
+## Change
+
+Large rigid compounds now expose disjoint BVH subtrees of at most 16 leaves to the spatial grid. Each hierarchy thread handles at most 256 leaf combinations with a 16-entry traversal stack. Small compounds retain their existing tree and traversal order.
+
+The count pass records accepted pairs as one-byte proxy-local leaf indices in traversal order. Emit copies these cached pairs after the exclusive scan; it no longer repeats transforms, sphere tests, or the tree walk. The leaf-node sphere already equals the previous collider sphere predicate, including hull padding, so the redundant second leaf test is removed.
+
+The hierarchy count/scan capacity is bounded by `min(maxPairs, proxyCount * (proxyCount - 1) / 2)` (with a one-entry empty-case allocation). Emit dispatches only the live proxy pairs. Explicit encoder boundaries protect scratch-buffer reuse and GPU-written indirect arguments during unprofiled execution.
+
+## Dishwasher results
+
+The harness copies the app’s `buildSimulation` and engine-independent `DishwasherDesign` sources. It constructs default generated layouts with seeds 0–2 and the reference layout, retaining all authored collision geometry, collision exclusions, margin, 20 solver iterations, 1/60 timestep, and 128 pair slots per collider. Each measurement restores the same initial solver snapshot, with 3 warmup frames and 12 profiled frames; baseline and optimized runs execute sequentially. No rendering or networking runs in the harness.
+
+| Layout | Candidates, both builds | Hierarchy before | Hierarchy after | Speedup | Profiled GPU total before → after |
+|---|---:|---:|---:|---:|---:|
+| 0 | 32,178 | 4.048 ms | 0.300 ms | 13.5× | 6.191 → 2.630 ms |
+| 1 | 53,353 | 3.375 ms | 0.228 ms | 14.8× | 5.846 → 2.991 ms |
+| 2 | 52,722 | 4.240 ms | 0.259 ms | 16.4× | 6.700 → 2.530 ms |
+| reference | 35,534 | 2.729 ms | 0.329 ms | 8.3× | 5.080 → 2.592 ms |
+
+Seed 0 has 37 bodies and 656 enabled colliders. Proxies increase from 37 to 64; the largest original compound has 124 colliders. Hierarchy scan entries fall from 83,968 to 2,016. Count falls from 1.961 to 0.259 ms; emit falls from 2.087 to 0.041 ms. The cache costs 516,096 bytes plus a 4,096-byte proxy-to-leaf table in this scene.
+
+GPU totals sum the existing encoder timestamp measurements. They are instrumented physics timings, not application frame times or FPS. Timing varies with GPU load. Snapshot restore wall time includes CPU copies and is deliberately excluded from the performance claim. These are frozen-state comparisons; trajectories need not match the previous build bit-for-bit because splitting large compounds changes pair enumeration order. Determinism within the new implementation remains tested.
+
+## Validation
+
+40 Metal GPU tests passed: the full `ConvexGPURuntimeTests` suite, contact-rich trajectory determinism, exact pair capacity, and overflow rejection. New checks cover:
+
+- Complete pair-set equality against a brute-force sphere oracle for mixed, rotated, uneven compounds with collision domains, shared geometry, and owner exclusions.
+- Disjoint, complete leaf coverage and the maximum subtree size.
+- Repeated snapshot restores preserving pair order without duplicates.
+- Full 16×16 cached tiles, exactly 4,096 output pairs, and checked overflow at 4,225.
+- A populated frame followed by an empty frame and contacts returning, with both unprofiled and profiled dispatch paths.
+
+```sh
+swift test --filter 'ConvexGPURuntimeTests|GPUSolverTests.testExactRigidPairCapacity|GPUSolverTests.testRigidPairOverflow|GPUSolverTests.testContactRichTrajectory'
+```
+
+Tests must run with Metal access; a sandbox that hides the GPU skips the Metal cases. Local raw profiles, the benchmark Swift source, machine-readable summary, and test log are under `artifacts/compound-broadphase/` (ignored generated artifacts).
+
+## Scope and tradeoffs
+
+The optimization applies to rigid compound scenes generally. Analytic scenes without compounds and deformable collision paths keep their existing broad phase. It uses the existing conservative sphere bounds and hull padding; tighter geometric bounds remain a separate improvement. More proxies can increase grid pair-generation work, which is included in the GPU totals above. The compact cache requires up to 256 bytes per reserved hierarchy proxy-pair entry, capped by the existing output pair capacity, plus 64 bytes per proxy.
+
+The TeleopKit app remains pinned to the baseline revision; these results use a separate headless harness linked to the optimization worktree.

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -1526,7 +1526,7 @@ public final class GPUSolver {
                 * MemoryLayout<ColliderBVHNodeGPU>.stride,
             "broadphaseBVHNodes")
         broadphaseProxyPairs = try makeBuf(
-            usesRigidColliderHierarchy ? maxPairs * 8 : 16,
+            usesRigidColliderHierarchy ? hierarchyPairCapacity * 8 : 16,
             "broadphaseProxyPairs")
         broadphaseProxyLeaves = try makeBuf(
             max(1, rigidBroadphaseProxyCount) * Self.rigidBroadphaseMaxLeavesPerProxy * 4,
@@ -1596,10 +1596,14 @@ public final class GPUSolver {
                                        "cellBodiesSorted")
         bodyCellSlot = try makeBuf(max(1, broadphaseItemCount) * 8,
                                    "bodyCellSlot")
-        pairCount = try makeBuf(max(maxPairs, broadphaseItemCount) * 4,
-                                "pairCount")
-        pairStart = try makeBuf(max(maxPairs, broadphaseItemCount) * 4,
-                                "pairStart")
+        // The two passes share scratch: one count per grid producer, then
+        // one count per possible proxy pair. Contact-output capacity is not
+        // the scan length. Retain both bounds for one- and two-proxy scenes.
+        let pairScanCapacity = usesRigidColliderHierarchy
+            ? max(hierarchyPairCapacity, broadphaseItemCount)
+            : max(maxPairs, broadphaseItemCount)
+        pairCount = try makeBuf(pairScanCapacity * 4, "pairCount")
+        pairStart = try makeBuf(pairScanCapacity * 4, "pairStart")
         pairs = try makeBuf(maxPairs * 8, "pairs")
         exclusions = try makeBuf(max(1, scene.joints.count + scene.springs.count
                                      + scene.collisionExclusions.count) * 8,

--- a/Sources/PhysicsAVBD/GPU/GPUSolver.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUSolver.swift
@@ -178,11 +178,13 @@ public final class GPUSolver {
     public let usesRigidColliderHierarchy: Bool
     public let rigidBroadphaseProxyCount: Int
     public let rigidBroadphaseBVHNodeCount: Int
+    let hierarchyPairCapacity: Int
     var broadphaseProxyOwner, broadphaseProxyLocalPosition: MTLBuffer
     var broadphaseProxyShape, broadphaseProxyGroup: MTLBuffer
     var broadphaseProxySharedCollision, broadphaseProxyShapeType: MTLBuffer
     var broadphaseProxyRoot, broadphaseBVHNodes: MTLBuffer
     var broadphaseProxyPairs: MTLBuffer
+    var broadphaseProxyLeaves, hierarchyLeafPairs: MTLBuffer
     /// Per-producer candidate counts and exclusive offsets. Pair emission is
     /// count/scan/scatter instead of atomic append so manifold identity and
     /// contact accumulation order are reproducible across Metal schedules.
@@ -544,13 +546,21 @@ public final class GPUSolver {
         var shapeTypes: [UInt32] = []
         var roots: [UInt32] = []
         var nodes: [ColliderBVHNodeGPU] = []
+        var leaves: [UInt32] = []
     }
 
-    /// Build one balanced body-local sphere BVH per collision domain. This is
-    /// used only by rigid-only scenes; deformable RT queries retain their
-    /// proven collider-level spatial grid. Single-collider bodies stay as
-    /// one-leaf proxies, while decomposed bodies broad-phase once and expand
-    /// only overlapping BVH leaves.
+    // Bound the work assigned to one hierarchy-expansion thread. A whole
+    // compound body (racks, rooms, decomposed meshes) can have thousands of
+    // leaves; making it one proxy serializes its child-pair search on one
+    // GPU lane. Disjoint subtrees give the grid tighter bounds and distribute
+    // that work without duplicating leaves or changing collision predicates.
+    // Keep the traversal stack in 21_hierarchy_broadphase.metal in sync.
+    static let rigidBroadphaseMaxLeavesPerProxy = 16
+
+    /// Build balanced body-local sphere BVHs, exposing bounded subtrees as
+    /// spatial-grid proxies. Used only by rigid-only scenes; deformable RT
+    /// queries retain their collider-level grid. Small compounds retain one
+    /// proxy and their established enumeration order.
     private static func makeRigidBroadphaseHierarchy(
         scene: PhysicsScene, convexUpload: ConvexGPUUpload
     ) -> RigidBroadphaseHierarchyUpload? {
@@ -649,19 +659,43 @@ public final class GPUSolver {
             }
 
             let root = build(colliders)
-            let rootNode = upload.nodes[Int(root)]
-            let particle = scene.bodies[key.body].isParticle
-            upload.owners.append(UInt32(key.body))
-            upload.localPositions.append(SIMD4(
-                rootNode.centerRadius.x, rootNode.centerRadius.y,
-                rootNode.centerRadius.z, 0))
-            upload.shapes.append(SIMD4(
-                0, 0, 0,
-                particle ? -rootNode.centerRadius.w : rootNode.centerRadius.w))
-            upload.groups.append(key.group)
-            upload.sharedCollision.append(key.shared ? 1 : 0)
-            upload.shapeTypes.append((rootNode.links.w & 2) != 0 ? 4 : 0)
-            upload.roots.append(root)
+            func appendProxies(_ nodeIndex: UInt32, leafCount: Int) {
+                let node = upload.nodes[Int(nodeIndex)]
+                if leafCount > rigidBroadphaseMaxLeavesPerProxy {
+                    let leftCount = leafCount / 2
+                    appendProxies(node.links.x, leafCount: leftCount)
+                    appendProxies(node.links.y, leafCount: leafCount - leftCount)
+                    return
+                }
+                let particle = scene.bodies[key.body].isParticle
+                upload.owners.append(UInt32(key.body))
+                upload.localPositions.append(SIMD4(
+                    node.centerRadius.x, node.centerRadius.y,
+                    node.centerRadius.z, 0))
+                upload.shapes.append(SIMD4(
+                    0, 0, 0,
+                    particle ? -node.centerRadius.w : node.centerRadius.w))
+                upload.groups.append(key.group)
+                upload.sharedCollision.append(key.shared ? 1 : 0)
+                upload.shapeTypes.append((node.links.w & 2) != 0 ? 4 : 0)
+                upload.roots.append(nodeIndex)
+                let leafBase = upload.leaves.count
+                func appendLeaves(_ index: UInt32) {
+                    let leafNode = upload.nodes[Int(index)]
+                    if leafNode.links.w & 1 != 0 {
+                        let ordinal = UInt32(upload.leaves.count - leafBase)
+                        upload.nodes[Int(index)].links.w |= ordinal << 2
+                        upload.leaves.append(leafNode.links.z)
+                    } else {
+                        appendLeaves(leafNode.links.x)
+                        appendLeaves(leafNode.links.y)
+                    }
+                }
+                appendLeaves(nodeIndex)
+                upload.leaves.append(contentsOf: repeatElement(UInt32.max,
+                    count: rigidBroadphaseMaxLeavesPerProxy - leafCount))
+            }
+            appendProxies(root, leafCount: colliders.count)
         }
         return upload
     }
@@ -1279,6 +1313,13 @@ public final class GPUSolver {
         // for batched robots: H1 keeps its analytic MJCF proxies for replay,
         // while only three exact USD hulls per environment are active.
         self.maxPairs = max(4096, enabledColliderCount * maxPairsPerBody)
+        // The expansion scan contains one entry per proxy pair, not per
+        // collider-pair output slot. Bound it by the number of distinct
+        // proxy pairs even when a caller reserves a large contact capacity.
+        let proxyProduct = broadphaseItemCount.multipliedReportingOverflow(
+            by: max(0, broadphaseItemCount - 1))
+        self.hierarchyPairCapacity = max(1, min(maxPairs,
+            proxyProduct.overflow ? maxPairs : proxyProduct.partialValue / 2))
         self.mapCapacity = Self.nextPow2(2 * maxPairs)
         let broadphaseGridItemCount = rigidHierarchy?.owners.count
             ?? enabledColliderCount
@@ -1487,6 +1528,16 @@ public final class GPUSolver {
         broadphaseProxyPairs = try makeBuf(
             usesRigidColliderHierarchy ? maxPairs * 8 : 16,
             "broadphaseProxyPairs")
+        broadphaseProxyLeaves = try makeBuf(
+            max(1, rigidBroadphaseProxyCount) * Self.rigidBroadphaseMaxLeavesPerProxy * 4,
+            "broadphaseProxyLeaves")
+        // Four bits identify each leaf within its proxy. Store the accepted
+        // pairs in traversal order (one byte each) so emit need not repeat
+        // any hierarchy search or change deterministic manifold ordering.
+        hierarchyLeafPairs = try makeBuf(usesRigidColliderHierarchy
+            ? hierarchyPairCapacity * Self.rigidBroadphaseMaxLeavesPerProxy
+                * Self.rigidBroadphaseMaxLeavesPerProxy : 16,
+            "hierarchyLeafPairs")
         joints = try makeBuf(max(1, numJoints) * MemoryLayout<JointGPU>.stride, "joints")
         springs = try makeBuf(max(1, numSprings) * MemoryLayout<SpringGPU>.stride, "springs")
         tets = try makeBuf(max(1, numTets) * MemoryLayout<TetGPU>.stride, "tets")
@@ -2178,12 +2229,13 @@ public final class GPUSolver {
                         to: broadphaseProxyShapeType)
             uploadArray(rigidHierarchy.roots, to: broadphaseProxyRoot)
             uploadArray(rigidHierarchy.nodes, to: broadphaseBVHNodes)
+            uploadArray(rigidHierarchy.leaves, to: broadphaseProxyLeaves)
         } else {
             for buffer in [
                 broadphaseProxyOwner, broadphaseProxyLocalPosition,
                 broadphaseProxyShape, broadphaseProxyGroup,
                 broadphaseProxySharedCollision, broadphaseProxyShapeType,
-                broadphaseProxyRoot, broadphaseBVHNodes,
+                broadphaseProxyRoot, broadphaseBVHNodes, broadphaseProxyLeaves,
             ] {
                 memset(buffer.contents(), 0, buffer.length)
             }
@@ -3538,6 +3590,7 @@ public final class GPUSolver {
          "hashedRigid": Int(params.numHashedRigid), "tris": numTris,
          "particles": numParticles, "gridHashSize": gridHashSize,
          "rigidProxies": rigidBroadphaseProxyCount, "maxPairs": maxPairs,
+         "hierarchyPairCapacity": usesRigidColliderHierarchy ? hierarchyPairCapacity : 0,
          "bodies": numBodies,
          "cellSizeMicrons": Int(params.cellSize * 1e6),
          "elemCellSizeMicrons": Int(params.elemCellSize * 1e6),
@@ -5656,8 +5709,11 @@ public final class GPUSolver {
             e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
         }
         if usesRigidColliderHierarchy {
-            if profiling { try stage("bp-pairs/bp_count_hierarchy_pairs") }
-            dispatch1D(enc, "bp_count_hierarchy_pairs", maxPairs) { e in
+            var hierarchyCount = UInt32(hierarchyPairCapacity)
+            // The proxy producer counts/starts are reused by expansion.
+            // Finish their consumers before rebinding them for the next pass.
+            try stage("bp-pairs/bp_count_hierarchy_pairs")
+            dispatch1D(enc, "bp_count_hierarchy_pairs", hierarchyPairCapacity) { e in
                 e.setBuffer(self.broadphaseProxyPairs, offset: 0, index: 0)
                 e.setBuffer(self.counters, offset: 0, index: 1)
                 e.setBuffer(self.pairCount, offset: 0, index: 2)
@@ -5666,34 +5722,27 @@ public final class GPUSolver {
                 e.setBuffer(self.broadphaseBVHNodes, offset: 0, index: 5)
                 e.setBuffer(self.posLin, offset: 0, index: 6)
                 e.setBuffer(self.posAng, offset: 0, index: 7)
-                e.setBuffer(self.colliderShape, offset: 0, index: 8)
-                e.setBuffer(self.colliderOwner, offset: 0, index: 9)
-                e.setBuffer(self.colliderLocalPosition, offset: 0, index: 10)
-                e.setBuffer(self.colliderShapeType, offset: 0, index: 11)
-                e.setBuffer(self.pairs, offset: 0, index: 12)
+                e.setBuffer(self.hierarchyLeafPairs, offset: 0, index: 8)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
-                           index: 13)
+                           index: 9)
+                e.setBytes(&hierarchyCount, length: 4, index: 10)
             }
             if profiling { try stage("bp-pairs/scan") }
             encodeScan(enc, input: pairCount, output: pairStart,
-                       count: maxPairs)
-            if profiling { try stage("bp-pairs/bp_emit_hierarchy_pairs") }
-            dispatch1D(enc, "bp_emit_hierarchy_pairs", maxPairs) { e in
+                       count: hierarchyPairCapacity)
+            // GPU-written indirect arguments must be visible before dispatch;
+            // this boundary is required in unprofiled execution as well.
+            try stage("bp-pairs/bp_emit_hierarchy_pairs")
+            dispatchIndirect(enc, "bp_emit_hierarchy_pairs", argsOffset: 0) { e in
                 e.setBuffer(self.broadphaseProxyPairs, offset: 0, index: 0)
                 e.setBuffer(self.counters, offset: 0, index: 1)
                 e.setBuffer(self.pairStart, offset: 0, index: 2)
-                e.setBuffer(self.broadphaseProxyOwner, offset: 0, index: 3)
-                e.setBuffer(self.broadphaseProxyRoot, offset: 0, index: 4)
-                e.setBuffer(self.broadphaseBVHNodes, offset: 0, index: 5)
-                e.setBuffer(self.posLin, offset: 0, index: 6)
-                e.setBuffer(self.posAng, offset: 0, index: 7)
-                e.setBuffer(self.colliderShape, offset: 0, index: 8)
-                e.setBuffer(self.colliderOwner, offset: 0, index: 9)
-                e.setBuffer(self.colliderLocalPosition, offset: 0, index: 10)
-                e.setBuffer(self.colliderShapeType, offset: 0, index: 11)
-                e.setBuffer(self.pairs, offset: 0, index: 12)
+                e.setBuffer(self.pairCount, offset: 0, index: 3)
+                e.setBuffer(self.broadphaseProxyLeaves, offset: 0, index: 4)
+                e.setBuffer(self.hierarchyLeafPairs, offset: 0, index: 5)
+                e.setBuffer(self.pairs, offset: 0, index: 6)
                 e.setBytes(&P, length: MemoryLayout<SimParamsGPU>.stride,
-                           index: 13)
+                           index: 7)
             }
             if profiling { try stage("bp-pairs/bp_finalize_hierarchy_pairs") }
             dispatch1D(enc, "bp_finalize_hierarchy_pairs", 1) { e in

--- a/Sources/PhysicsAVBD/GPU/GPUTypes.swift
+++ b/Sources/PhysicsAVBD/GPU/GPUTypes.swift
@@ -222,7 +222,8 @@ public struct ConvexEdgeGPU {
 
 /// One node of the immutable body-local broadphase hierarchy. Bounds are
 /// spheres so live rigid transforms require only one rotation/translation.
-/// links: left node, right node, leaf collider, flags (bit 0 leaf, bit 1 hull).
+/// links: left node, right node, leaf collider, flags (bit 0 leaf, bit 1 hull,
+/// bits 2–5 leaf ordinal within its bounded proxy subtree).
 public struct ColliderBVHNodeGPU {
     public var centerRadius: SIMD4<Float> = .zero
     public var links: SIMD4<UInt32> = .zero

--- a/Sources/PhysicsAVBD/Shaders/21_hierarchy_broadphase.metal
+++ b/Sources/PhysicsAVBD/Shaders/21_hierarchy_broadphase.metal
@@ -146,8 +146,13 @@ kernel void bp_finalize_hierarchy_pairs(
     device const uint* pairStarts [[buffer(1)]],
     device atomic_uint* counters [[buffer(2)]],
     device uint* dispatchArgs [[buffer(3)]],
-    constant SimParams& P [[buffer(4)]])
+    constant SimParams& P [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
 {
+    // dispatch1D rounds up to a complete threadgroup. This kernel replaces
+    // the proxy count with the leaf count; another writer could read that
+    // new value as a proxy index and corrupt counts or access past the scan.
+    if (gid != 0u) return;
     uint rawProxyCount = atomic_load_explicit(
         &counters[CTR_PAIR_CANDIDATES], memory_order_relaxed);
     uint proxyCount = atomic_load_explicit(

--- a/Sources/PhysicsAVBD/Shaders/21_hierarchy_broadphase.metal
+++ b/Sources/PhysicsAVBD/Shaders/21_hierarchy_broadphase.metal
@@ -5,7 +5,11 @@ using namespace metal;
 // This source is compiled into a separate Metal library so merely enabling
 // the feature in the product cannot perturb established analytic broadphase
 // fast-math code generation in scenes that do not use the hierarchy.
-#define BP_BVH_STACK_CAPACITY 64
+// Each proxy is a balanced subtree of at most 16 leaves (see
+// rigidBroadphaseMaxLeavesPerProxy). Splitting one side per level gives a
+// maximum paired depth of 8 and at most 9 pending entries. Leave headroom
+// while avoiding the original 512-byte private stack per GPU thread.
+#define BP_BVH_STACK_CAPACITY 16
 
 struct ColliderBVHNodeGPU {
     float4 centerRadius;
@@ -33,37 +37,6 @@ inline float bpBVHPairRadius(
     return result;
 }
 
-inline float3 bpHierarchyColliderCenter(
-    device const float4* posLin,
-    device const float4* posAng,
-    device const uint* colliderOwner,
-    device const float4* colliderLocalPosition,
-    uint collider)
-{
-    uint body = colliderOwner[collider];
-    return posLin[body].xyz
-        + q_rotate(posAng[body], colliderLocalPosition[collider].xyz);
-}
-
-inline float bpHierarchyLeafPairRadius(
-    float signedRadiusA, float signedRadiusB,
-    uint shapeTypeA, uint shapeTypeB,
-    constant SimParams& P)
-{
-    float radiusA = fabs(signedRadiusA);
-    float radiusB = fabs(signedRadiusB);
-    float result = radiusA + radiusB;
-    bool hullA = (shapeTypeA & SHAPE_KIND_MASK) == 4u;
-    bool hullB = (shapeTypeB & SHAPE_KIND_MASK) == 4u;
-    if (hullA || hullB) {
-        float cap = min(0.25f,
-            max(4.0f * P.collisionMargin,
-                3.0f * min(radiusA, radiusB)));
-        result += P.collisionMargin + cap;
-    }
-    return result;
-}
-
 inline uint bpExpandHierarchyPair(
     uint2 proxyPair,
     device const uint* proxyOwner,
@@ -71,13 +44,8 @@ inline uint bpExpandHierarchyPair(
     device const ColliderBVHNodeGPU* nodes,
     device const float4* posLin,
     device const float4* posAng,
-    device const float4* colliderShape,
-    device const uint* colliderOwner,
-    device const float4* colliderLocalPosition,
-    device const uint* colliderShapeType,
     constant SimParams& P,
-    bool emit, uint outputBase,
-    device uint2* pairs)
+    device uchar* leafPairs)
 {
     uint bodyA = proxyOwner[proxyPair.x];
     uint bodyB = proxyOwner[proxyPair.y];
@@ -99,25 +67,11 @@ inline uint bpExpandHierarchyPair(
         bool leafA = (nodeA.links.w & 1u) != 0u;
         bool leafB = (nodeB.links.w & 1u) != 0u;
         if (leafA && leafB) {
-            uint colliderA = nodeA.links.z;
-            uint colliderB = nodeB.links.z;
-            float3 leafCenterA = bpHierarchyColliderCenter(
-                posLin, posAng, colliderOwner,
-                colliderLocalPosition, colliderA);
-            float3 leafCenterB = bpHierarchyColliderCenter(
-                posLin, posAng, colliderOwner,
-                colliderLocalPosition, colliderB);
-            float leafRadius = bpHierarchyLeafPairRadius(
-                colliderShape[colliderA].w, colliderShape[colliderB].w,
-                colliderShapeType[colliderA],
-                colliderShapeType[colliderB], P);
-            if (distance_squared(leafCenterA, leafCenterB)
-                    > leafRadius * leafRadius) continue;
-            uint slot = outputBase + count;
-            if (emit && slot < P.maxPairs) {
-                pairs[slot] = uint2(
-                    min(colliderA, colliderB), max(colliderA, colliderB));
-            }
+            // Leaf spheres are the same conservative bounds used by the
+            // collider predicate, including hull contact padding above.
+            // Cache their proxy-local ordinals in the original DFS order.
+            leafPairs[count] = uchar((nodeA.links.w >> 2)
+                | ((nodeB.links.w >> 2) << 4));
             count++;
             continue;
         }
@@ -147,48 +101,44 @@ kernel void bp_count_hierarchy_pairs(
     device const ColliderBVHNodeGPU* nodes [[buffer(5)]],
     device const float4* posLin [[buffer(6)]],
     device const float4* posAng [[buffer(7)]],
-    device const float4* colliderShape [[buffer(8)]],
-    device const uint* colliderOwner [[buffer(9)]],
-    device const float4* colliderLocalPosition [[buffer(10)]],
-    device const uint* colliderShapeType [[buffer(11)]],
-    device uint2* pairs [[buffer(12)]],
-    constant SimParams& P [[buffer(13)]],
+    device uchar* leafPairs [[buffer(8)]],
+    constant SimParams& P [[buffer(9)]],
+    constant uint& pairCapacity [[buffer(10)]],
     uint gid [[thread_position_in_grid]])
 {
-    if (gid >= P.maxPairs) return;
+    if (gid >= pairCapacity) return;
     uint proxyCount = atomic_load_explicit(
         &counters[CTR_PAIRS], memory_order_relaxed);
     pairCounts[gid] = gid < proxyCount ? bpExpandHierarchyPair(
         proxyPairs[gid], proxyOwner, proxyRoot, nodes, posLin, posAng,
-        colliderShape, colliderOwner, colliderLocalPosition,
-        colliderShapeType, P, false, 0u, pairs) : 0u;
+        P, leafPairs + size_t(gid) * 256u) : 0u;
 }
 
 kernel void bp_emit_hierarchy_pairs(
     device const uint2* proxyPairs [[buffer(0)]],
     device const atomic_uint* counters [[buffer(1)]],
     device const uint* pairStarts [[buffer(2)]],
-    device const uint* proxyOwner [[buffer(3)]],
-    device const uint* proxyRoot [[buffer(4)]],
-    device const ColliderBVHNodeGPU* nodes [[buffer(5)]],
-    device const float4* posLin [[buffer(6)]],
-    device const float4* posAng [[buffer(7)]],
-    device const float4* colliderShape [[buffer(8)]],
-    device const uint* colliderOwner [[buffer(9)]],
-    device const float4* colliderLocalPosition [[buffer(10)]],
-    device const uint* colliderShapeType [[buffer(11)]],
-    device uint2* pairs [[buffer(12)]],
-    constant SimParams& P [[buffer(13)]],
+    device const uint* pairCounts [[buffer(3)]],
+    device const uint* proxyLeaves [[buffer(4)]],
+    device const uchar* leafPairs [[buffer(5)]],
+    device uint2* pairs [[buffer(6)]],
+    constant SimParams& P [[buffer(7)]],
     uint gid [[thread_position_in_grid]])
 {
-    if (gid >= P.maxPairs) return;
     uint proxyCount = atomic_load_explicit(
         &counters[CTR_PAIRS], memory_order_relaxed);
     if (gid >= proxyCount) return;
-    (void)bpExpandHierarchyPair(
-        proxyPairs[gid], proxyOwner, proxyRoot, nodes, posLin, posAng,
-        colliderShape, colliderOwner, colliderLocalPosition,
-        colliderShapeType, P, true, pairStarts[gid], pairs);
+    uint count = pairCounts[gid];
+    // Overflow is surfaced by finalize, never decoded as cached leaf data.
+    if (count > 256u) return;
+    uint base = pairStarts[gid];
+    uint2 proxy = proxyPairs[gid];
+    for (uint i = 0; i < count && base + i < P.maxPairs; i++) {
+        uint code = leafPairs[size_t(gid) * 256u + i];
+        uint a = proxyLeaves[size_t(proxy.x) * 16u + (code & 15u)];
+        uint b = proxyLeaves[size_t(proxy.y) * 16u + (code >> 4)];
+        pairs[base + i] = uint2(min(a, b), max(a, b));
+    }
 }
 
 kernel void bp_finalize_hierarchy_pairs(
@@ -200,7 +150,10 @@ kernel void bp_finalize_hierarchy_pairs(
 {
     uint rawProxyCount = atomic_load_explicit(
         &counters[CTR_PAIR_CANDIDATES], memory_order_relaxed);
-    uint n = pairStarts[P.maxPairs - 1u] + pairCounts[P.maxPairs - 1u];
+    uint proxyCount = atomic_load_explicit(
+        &counters[CTR_PAIRS], memory_order_relaxed);
+    uint n = proxyCount == 0u ? 0u
+        : pairStarts[proxyCount - 1u] + pairCounts[proxyCount - 1u];
     if (rawProxyCount > P.maxPairs) n = max(n, P.maxPairs + 1u);
     atomic_store_explicit(&counters[CTR_PAIR_CANDIDATES], n,
                           memory_order_relaxed);

--- a/Tests/PhysicsAVBDTests/ConvexGPURuntimeTests.swift
+++ b/Tests/PhysicsAVBDTests/ConvexGPURuntimeTests.swift
@@ -1281,7 +1281,8 @@ final class ConvexGPURuntimeTests: XCTestCase {
         XCTAssertTrue(solver.usesRigidColliderHierarchy)
         XCTAssertTrue(GPUSolver.requiredHierarchyKernelNames
             .isSubset(of: solver.pso.keys))
-        XCTAssertEqual(solver.rigidBroadphaseProxyCount, 2)
+        XCTAssertGreaterThan(solver.rigidBroadphaseProxyCount, 2,
+            "large compounds must distribute expansion across multiple proxies")
         XCTAssertEqual(solver.rigidBroadphaseBVHNodeCount, 254)
         try solver.submitStep()
         try solver.synchronize()
@@ -1294,6 +1295,157 @@ final class ConvexGPURuntimeTests: XCTestCase {
             Set([$0.0, $0.1]) == Set([base, moving])
         })
         XCTAssertTrue(manifoldSnapshots(solver).allSatisfy(\.finite))
+    }
+
+    func testHierarchySubtreesPreserveAllEligibleSpherePairs() throws {
+        try requireMetal()
+        var scene = PhysicsScene(name: "compound-subtree-pair-oracle")
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        scene.settings.collisionMargin = 0.007
+        let asset = try tetraAsset(offset: F3(0.07, -0.11, 0.03))
+        var owners: [Int] = []
+        // Unequal, non-power-of-two leaf counts exercise both frontier
+        // branches. Rotated, mixed analytic/convex compounds cover radius
+        // padding, local transforms, collision domains and owner exclusions.
+        for (bodyIndex, count) in [67, 35, 19, 1].enumerated() {
+            let body = scene.addBody(
+                size: F3(repeating: 1), density: bodyIndex == 0 ? 0 : 1, friction: 0.5,
+                position: F3(Float(bodyIndex) * 0.31, 0.17, 0.23),
+                rotation: Quat(angle: Float(bodyIndex) * 0.19,
+                               axis: normalize(F3(1, 2, 3))),
+                collisionEnabled: false)
+            owners.append(body)
+            for index in 0..<count {
+                let local = F3(Float(index % 7) * 0.61,
+                               Float(index / 7) * 0.53, 0.13)
+                let collider: Int
+                if index % 3 == 0 {
+                    collider = scene.addConvexCollider(
+                        body: body, asset: asset, localPosition: local,
+                        localRotation: Quat(angle: 0.21, axis: F3(0, 1, 0)))
+                } else {
+                    collider = scene.addCollider(
+                        body: body, size: F3(0.83, 0.09, 0.07),
+                        localPosition: local,
+                        localRotation: Quat(angle: 0.37, axis: F3(1, 0, 0)))
+                }
+                scene.colliders[collider].collisionGroup = bodyIndex == 0
+                    ? 0 : (index % 5 == 0 ? 2 : 1)
+                scene.colliders[collider].collidesWithSharedGeometry = index % 4 != 0
+            }
+        }
+        scene.addCollisionExclusion(bodyA: owners[1], bodyB: owners[3])
+        let solver = try GPUSolver(scene: scene, maxPairsPerBody: 64)
+        let nodeBuffer = solver.broadphaseBVHNodes.contents()
+            .assumingMemoryBound(to: ColliderBVHNodeGPU.self)
+        let roots = solver.broadphaseProxyRoot.contents()
+            .assumingMemoryBound(to: UInt32.self)
+        func leafIDs(_ root: UInt32) -> [UInt32] {
+            let node = nodeBuffer[Int(root)]
+            if node.links.w & 1 != 0 { return [node.links.z] }
+            return leafIDs(node.links.x) + leafIDs(node.links.y)
+        }
+        var covered: [UInt32] = []
+        for proxy in 0..<solver.rigidBroadphaseProxyCount {
+            let leaves = leafIDs(roots[proxy])
+            XCTAssertLessThanOrEqual(leaves.count,
+                                    GPUSolver.rigidBroadphaseMaxLeavesPerProxy)
+            covered += leaves
+        }
+        XCTAssertEqual(covered.sorted(), scene.colliders.indices
+            .filter { scene.colliders[$0].collisionEnabled }.map(UInt32.init))
+
+        let shape = solver.colliderShape.contents().assumingMemoryBound(to: SIMD4<Float>.self)
+        let local = solver.colliderLocalPosition.contents().assumingMemoryBound(to: SIMD4<Float>.self)
+        let shapeType = solver.colliderShapeType.contents().assumingMemoryBound(to: UInt32.self)
+        func center(_ index: Int) -> F3 {
+            let body = scene.bodies[scene.colliders[index].body]
+            let p = local[index]
+            return body.position + body.rotation.act(F3(p.x, p.y, p.z))
+        }
+        var expected = Set<SIMD2<UInt32>>()
+        for a in scene.colliders.indices {
+            for b in scene.colliders.indices where b > a {
+                guard scene.canPotentiallyCollide(colliderA: a, colliderB: b) else { continue }
+                let ra = abs(shape[a].w), rb = abs(shape[b].w)
+                var radius = ra + rb
+                if shapeType[a] & 15 == 4 || shapeType[b] & 15 == 4 {
+                    radius += scene.settings.collisionMargin + min(0.25,
+                        max(4 * scene.settings.collisionMargin, 3 * min(ra, rb)))
+                }
+                if simd_length_squared(center(a) - center(b)) <= radius * radius {
+                    expected.insert(SIMD2(UInt32(a), UInt32(b)))
+                }
+            }
+        }
+        XCTAssertFalse(expected.isEmpty)
+        let initial = solver.captureSimulationSnapshot()
+        var first: [SIMD2<UInt32>]?
+        for _ in 0..<3 {
+            solver.restoreSimulationSnapshot(initial)
+            try solver.submitStep()
+            try solver.synchronize()
+            XCTAssertNil(solver.runtimeFailure)
+            let emitted = Array(UnsafeBufferPointer(
+                start: solver.pairs.contents().assumingMemoryBound(to: SIMD2<UInt32>.self),
+                count: solver.lastNumPairs))
+            XCTAssertEqual(emitted.count, Set(emitted).count, "no duplicate collider pairs")
+            XCTAssertTrue(Set(emitted) == expected,
+                "subtrees must preserve all \(expected.count) pairs, got \(emitted.count)")
+            if let first { XCTAssertTrue(emitted == first, "stable emission order") }
+            else { first = emitted }
+        }
+    }
+
+    func testHierarchyCachedPairsHandleFullTilesEmptyFramesAndOverflow() throws {
+        try requireMetal()
+        for leafCount in [16, 64, 65] {
+            var scene = PhysicsScene(name: "hierarchy-cache-capacity-\(leafCount)")
+            scene.settings.gravity = 0
+            scene.settings.iterations = 0
+            let base = scene.addBody(size: F3(repeating: 1), density: 0,
+                friction: 0.5, position: .zero, collisionEnabled: false)
+            let moving = scene.addBody(size: F3(repeating: 1), density: 1,
+                friction: 0.5, position: F3(0, 0, 0.1), collisionEnabled: false)
+            for index in 0..<leafCount {
+                for body in [base, moving] {
+                    scene.addCollider(body: body, size: F3(repeating: 0.5),
+                        localPosition: F3(Float(index) * 0.0001, 0, 0), shape: .sphere)
+                }
+            }
+            let solver = try GPUSolver(scene: scene)
+            XCTAssertLessThan(solver.hierarchyPairCapacity, solver.maxPairs)
+            try solver.submitStep()
+            let required = leafCount * leafCount
+            if required > solver.maxPairs {
+                XCTAssertThrowsError(try solver.synchronize()) { error in
+                    XCTAssertEqual(error as? GPUSolver.RuntimeFailure,
+                        .rigidPairCapacity(frame: 1, required: required, capacity: 4096))
+                }
+                continue
+            }
+            try solver.synchronize()
+            XCTAssertEqual(solver.lastPairCandidates, required)
+            let emitted = Array(UnsafeBufferPointer(
+                start: solver.pairs.contents().assumingMemoryBound(to: SIMD2<UInt32>.self),
+                count: solver.lastNumPairs))
+            XCTAssertEqual(Set(emitted).count, required,
+                "all 256 entries in full tiles must decode to distinct pairs")
+            // Shrink the live proxy list to zero after a full cache, then
+            // restore contacts. Finalization must not read stale scan tails.
+            solver.setBodyPose(moving, position: F3(100, 0, 0),
+                               rotation: Quat(real: 1, imag: .zero))
+            try solver.submitStep()
+            try solver.synchronize()
+            XCTAssertEqual(solver.lastPairCandidates, 0)
+            solver.setBodyPose(moving, position: F3(0, 0, 0.1),
+                               rotation: Quat(real: 1, imag: .zero))
+            solver.profiling = true
+            try solver.submitStep()
+            try solver.synchronize()
+            XCTAssertEqual(solver.lastPairCandidates, required)
+        }
     }
 
     func testRigidColliderHierarchySupportsBodyAcrossCompoundSeam() throws {

--- a/Tests/PhysicsAVBDTests/ConvexGPURuntimeTests.swift
+++ b/Tests/PhysicsAVBDTests/ConvexGPURuntimeTests.swift
@@ -1297,6 +1297,98 @@ final class ConvexGPURuntimeTests: XCTestCase {
         XCTAssertTrue(manifoldSnapshots(solver).allSatisfy(\.finite))
     }
 
+    func testHierarchyFinalizationHasExactlyOneWriter() throws {
+        try requireMetal()
+        var scene = PhysicsScene(name: "hierarchy-finalizer-writer")
+        let body = scene.addBody(size: F3(repeating: 1), density: 1,
+            friction: 0.5, position: .zero, collisionEnabled: false)
+        for _ in 0..<2 { scene.addCollider(body: body, size: F3(repeating: 0.5)) }
+        let solver = try GPUSolver(scene: scene)
+        let device = solver.device
+        let counts = try XCTUnwrap(device.makeBuffer(length: 4096 * 4, options: .storageModeShared))
+        let starts = try XCTUnwrap(device.makeBuffer(length: 4096 * 4, options: .storageModeShared))
+        memset(counts.contents(), 0, counts.length)
+        memset(starts.contents(), 0, starts.length)
+        counts.contents().assumingMemoryBound(to: UInt32.self)[0] = 256
+        // If another invocation mistakes the published contact count for a
+        // proxy count, this valid allocation leads it to a zero sentinel.
+        let counters = solver.counters.contents().assumingMemoryBound(to: UInt32.self)
+        counters[GPUCounters.pairs] = 1
+        counters[GPUCounters.pairCandidates] = 1
+        let cmd = try XCTUnwrap(solver.queue.makeCommandBuffer())
+        let encoder = try XCTUnwrap(cmd.makeComputeCommandEncoder())
+        encoder.setComputePipelineState(try XCTUnwrap(solver.pso["bp_finalize_hierarchy_pairs"]))
+        encoder.setBuffer(counts, offset: 0, index: 0)
+        encoder.setBuffer(starts, offset: 0, index: 1)
+        encoder.setBuffer(solver.counters, offset: 0, index: 2)
+        encoder.setBuffer(solver.dispatchArgs, offset: 0, index: 3)
+        var params = solver.params
+        encoder.setBytes(&params, length: MemoryLayout<SimParamsGPU>.stride, index: 4)
+        // Exercise multiple scheduling waves with an oversized dispatch;
+        // production dispatch1D also launches multiple SIMD groups.
+        encoder.dispatchThreadgroups(MTLSize(width: 4096, height: 1, depth: 1),
+            threadsPerThreadgroup: MTLSize(width: 1, height: 1, depth: 1))
+        encoder.endEncoding()
+        cmd.commit(); cmd.waitUntilCompleted()
+        XCTAssertEqual(cmd.status, .completed)
+        XCTAssertEqual(counters[GPUCounters.pairs], 256)
+        XCTAssertEqual(counters[GPUCounters.pairCandidates], 256)
+        XCTAssertEqual(solver.dispatchArgs.contents().assumingMemoryBound(to: UInt32.self)[0], 4)
+    }
+
+    func testHierarchyScratchUsesBothProducerAndProxyPairBounds() throws {
+        try requireMetal()
+        for bodyCount in [1, 2, 5] {
+            var scene = PhysicsScene(name: "hierarchy-small-proxy-scratch")
+            scene.settings.gravity = 0
+            scene.settings.iterations = 0
+            for _ in 0..<bodyCount {
+                let body = scene.addBody(size: F3(repeating: 1), density: 1,
+                    friction: 0.5, position: .zero, collisionEnabled: false)
+                for _ in 0..<2 {
+                    scene.addCollider(body: body, size: F3(repeating: 0.5), shape: .sphere)
+                }
+            }
+            let solver = try GPUSolver(scene: scene, maxPairsPerBody: 128)
+            XCTAssertEqual(solver.rigidBroadphaseProxyCount, bodyCount)
+            let pairCapacity = max(1, bodyCount * (bodyCount - 1) / 2)
+            let scanCapacity = max(pairCapacity, bodyCount)
+            XCTAssertEqual(solver.broadphaseProxyPairs.length, max(16, pairCapacity * 8))
+            XCTAssertEqual(solver.pairCount.length, max(16, scanCapacity * 4))
+            XCTAssertEqual(solver.pairStart.length, max(16, scanCapacity * 4))
+            try solver.submitStep()
+            try solver.synchronize()
+            XCTAssertEqual(solver.lastPairCandidates, bodyCount * (bodyCount - 1) / 2 * 4)
+        }
+    }
+
+    func testHierarchyRejectsProxyOverflowBeforeExpandingMissingPairs() throws {
+        try requireMetal()
+        var scene = PhysicsScene(name: "hierarchy-proxy-overflow")
+        scene.settings.gravity = 0
+        scene.settings.iterations = 0
+        for _ in 0..<100 {
+            let body = scene.addBody(size: F3(repeating: 1), density: 1,
+                friction: 0.5, position: .zero, collisionEnabled: false)
+            for _ in 0..<2 {
+                scene.addCollider(body: body, size: F3(repeating: 0.5), shape: .sphere)
+            }
+        }
+        let solver = try GPUSolver(scene: scene)
+        XCTAssertEqual(solver.hierarchyPairCapacity, 4096)
+        // 4,950 eligible proxy pairs exceed the cache's 4,096 entries;
+        // expansion must read only initialized pairs and fail explicitly.
+        try solver.submitStep()
+        XCTAssertThrowsError(try solver.synchronize()) { error in
+            guard case let GPUSolver.RuntimeFailure.rigidPairCapacity(frame, required, capacity) = error else {
+                return XCTFail("unexpected failure: \(error)")
+            }
+            XCTAssertEqual(frame, 1)
+            XCTAssertEqual(capacity, 4096)
+            XCTAssertGreaterThan(required, capacity)
+        }
+    }
+
     func testHierarchySubtreesPreserveAllEligibleSpherePairs() throws {
         try requireMetal()
         var scene = PhysicsScene(name: "compound-subtree-pair-oracle")


### PR DESCRIPTION
Large rigid compounds assigned an entire hierarchy search to one GPU thread, and the emit pass repeated that search. Split compounds into disjoint subtrees of at most 16 leaves, cache accepted leaf pairs during count, and emit from that cache in traversal order. Bound proxy-pair and shared count/scan storage by possible proxy pairs and grid producers, and dispatch emit from the live proxy count. Finalization has one writer so publishing the leaf count cannot race with another invocation reading it as a proxy count. Explicit encoder boundaries make scratch reuse and indirect dispatch correct on the first unprofiled frame.

On the dishwasher scene (Apple M5, release build, seed 0):

| Profiled GPU work | Before | After |
| --- | ---: | ---: |
| Hierarchy count | 1.961 ms | 0.259 ms |
| Hierarchy emit | 2.087 ms | 0.041 ms |
| Total physics | 6.191 ms | 2.630 ms |

Across generated seeds 0–2 and the reference layout, hierarchy count plus emit is 8.3–16.4× faster with identical candidate counts. Each run profiles 12 frames restored from the same initial snapshot after three warmup frames; these are instrumented physics timings, not application FPS. Full measurements and memory tradeoffs are in `Documentation/CompoundBroadphasePerformance.md`.

Validation: 43 Metal GPU tests passed with API and shader validation enabled, covering the full convex runtime suite, pair completeness against a brute-force oracle, disjoint subtree coverage, deterministic emission, full cached tiles, exact capacity, overflow rejection, populated/empty/populated frame transitions, small-proxy scratch bounds, raw proxy overflow, and finalizer scheduling stress.

```sh
MTL_DEBUG_LAYER=1 MTL_SHADER_VALIDATION=1 swift test -c release --filter 'ConvexGPURuntimeTests|GPUSolverTests.testExactRigidPairCapacity|GPUSolverTests.testRigidPairOverflow|GPUSolverTests.testContactRichTrajectory'
```

Splitting large compounds changes enumeration order, so trajectories need not match the old build bit-for-bit. The new implementation remains deterministic. The cache adds up to 256 bytes per reserved hierarchy proxy-pair entry, capped by the existing pair capacity, plus 64 bytes per proxy. The dishwasher app's pinned engine dependency is unchanged.
