### PR TITLE
Fix bright Fast AO cracks at concave wall joints

### DIFF
--- a/Sources/GPUSimRenderer/AmbientOcclusionShaders.swift
+++ b/Sources/GPUSimRenderer/AmbientOcclusionShaders.swift
@@ -2,13 +2,14 @@
 /// GTAO slice integration: Jimenez et al. 2016.
 /// Finite intervals: Therrien et al. 2023, https://arxiv.org/abs/2301.11376.
 let ambientOcclusionShaderSource = gtaoSamplingShaderSource + """
-inline float3 gtaoGeometricNormal(uint2 pixel, float3 P, float3 N,
+inline float3 gtaoGeometricNormal(uint2 pixel, float centerDepth, float3 P, float3 N,
     constant Uniforms& U, depth2d<float> depthTex) {
     float centerZ = P.z;
     float2 pixelToView = 2.0 * U.aoProjection.zw / U.screen.xy;
-    // Reconstruct the geometric plane from the closest depth neighbor on
-    // each axis. Quad derivatives can span silhouettes and invent a plane
-    // between different objects. Smoothed normals remain the shading basis.
+    // A closer depth can belong to the other face of a concave crease.
+    // Select the side whose two depths extrapolate back to this receiver.
+    // Hardware depth is affine over a projected plane; linear view Z is not.
+    // Smoothed normals remain the shading basis.
     float3 neighbors[4];
     constexpr int2 axisOffsets[4] = { int2(-1,0), int2(1,0), int2(0,-1), int2(0,1) };
     float distances[4];
@@ -20,7 +21,12 @@ inline float3 gtaoGeometricNormal(uint2 pixel, float3 P, float3 N,
         float zq = valid ? U.aoProjection.y / (dq - U.aoProjection.x) : centerZ;
         neighbors[i] = float3((float2(q) + 0.5 - U.reconstruction.yz * U.screen.xy)
             * pixelToView - U.aoProjection.zw, 1.0) * zq;
-        distances[i] = valid ? abs(zq - centerZ) : INFINITY;
+        int2 q2 = int2(pixel) + axisOffsets[i] * 2;
+        bool valid2 = all(q2 >= 0) && all(q2 < int2(U.screen.xy));
+        float d2 = valid2 ? depthTex.read(uint2(q2)) : 1.0;
+        valid2 = valid2 && d2 < 1.0;
+        distances[i] = valid ? (valid2 ? abs((2.0 * dq - d2) - centerDepth)
+                                                     : abs(dq - centerDepth)) : INFINITY;
     }
     float3 dx = distances[0] < distances[1] ? P-neighbors[0] : neighbors[1]-P;
     float3 dy = distances[2] < distances[3] ? P-neighbors[2] : neighbors[3]-P;
@@ -79,7 +85,7 @@ fragment float4 gtao_fragment(FSOut in [[stage_in]],
     // instead of letting a few-pixel march invent large-scale occlusion
     float farFade = saturate((pxRadius - 2.5) / 6.0);
     if (farFade <= 0.0) return float4(1);
-    float3 geometricN = gtaoGeometricNormal(uint2(in.position.xy), P, N, U, depthTex);
+    float3 geometricN = gtaoGeometricNormal(uint2(in.position.xy), dC, P, N, U, depthTex);
     pxRadius = min(pxRadius, 96.0);
     // the falloff must use the radius we ACTUALLY march (post-clamp), or
     // near-camera AO reaches past its sampled range and over-darkens

--- a/Sources/GPUSimRenderer/AmbientOcclusionShaders.swift
+++ b/Sources/GPUSimRenderer/AmbientOcclusionShaders.swift
@@ -12,7 +12,8 @@ inline float3 gtaoGeometricNormal(uint2 pixel, float centerDepth, float3 P, floa
     // Smoothed normals remain the shading basis.
     float3 neighbors[4];
     constexpr int2 axisOffsets[4] = { int2(-1,0), int2(1,0), int2(0,-1), int2(0,1) };
-    float distances[4];
+    float distances[4], adjacentErrors[4];
+    bool hasSecond[4];
     for (int i = 0; i < 4; ++i) {
         int2 q = int2((float2(pixel) + 0.5)) + axisOffsets[i];
         bool valid = all(q >= 0) && all(q < int2(U.screen.xy));
@@ -25,8 +26,19 @@ inline float3 gtaoGeometricNormal(uint2 pixel, float centerDepth, float3 P, floa
         bool valid2 = all(q2 >= 0) && all(q2 < int2(U.screen.xy));
         float d2 = valid2 ? depthTex.read(uint2(q2)) : 1.0;
         valid2 = valid2 && d2 < 1.0;
-        distances[i] = valid ? (valid2 ? abs((2.0 * dq - d2) - centerDepth)
-                                                     : abs(dq - centerDepth)) : INFINITY;
+        adjacentErrors[i] = valid ? abs(dq - centerDepth) : INFINITY;
+        hasSecond[i] = valid && valid2;
+        distances[i] = hasSecond[i] ? abs((2.0 * dq - d2) - centerDepth) : INFINITY;
+    }
+    // Compare like metrics within each axis. An extrapolation residual on
+    // an unrelated plane can be zero; it must not outrank an adjacent-depth
+    // difference merely because the other second tap is off-screen or empty.
+    for (int axis = 0; axis < 2; ++axis) {
+        int a = axis * 2, b = a + 1;
+        if (!(hasSecond[a] && hasSecond[b])) {
+            distances[a] = adjacentErrors[a];
+            distances[b] = adjacentErrors[b];
+        }
     }
     float3 dx = distances[0] < distances[1] ? P-neighbors[0] : neighbors[1]-P;
     float3 dy = distances[2] < distances[3] ? P-neighbors[2] : neighbors[3]-P;

--- a/Sources/GPUSimRenderer/ScreenSpaceShaders.swift
+++ b/Sources/GPUSimRenderer/ScreenSpaceShaders.swift
@@ -355,7 +355,7 @@ inline float4 filterVisibility(FSOut in, constant Uniforms& U,
     float3 planeN = float3(0);
     if (wantDirect) tolerance = max(0.003, P.z / U.screen.z * 1.5);
     if (wantAmbient) {
-        planeN = gtaoGeometricNormal(pixel, P, N, U, depth);
+        planeN = gtaoGeometricNormal(pixel, d, P, N, U, depth);
         planeTolerance = max(0.00025, P.z / U.screen.z * 0.25);
     }
     float2 sum = float2(0); float2 weights = float2(0);

--- a/Tests/GPUSimRendererTests/GTAONormalBoundaryTests.swift
+++ b/Tests/GPUSimRendererTests/GTAONormalBoundaryTests.swift
@@ -1,0 +1,88 @@
+import Metal
+import simd
+import XCTest
+@testable import GPUSimRenderer
+
+final class GTAONormalBoundaryTests: XCTestCase {
+    func testMissingSecondNeighborUsesComparableErrorsOnBothSides() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { throw XCTSkip("Metal unavailable") }
+        let library = try device.makeLibrary(source: renderShaderSource + """
+        struct BoundaryDepth { float depth [[depth(any)]]; };
+        fragment BoundaryDepth normal_fixture_depth(FSOut in [[stage_in]], device const float* values [[buffer(0)]]) {
+            BoundaryDepth out; out.depth = values[uint(in.position.y)*9u+uint(in.position.x)]; return out;
+        }
+        fragment float4 normal_boundary_fixture(FSOut in [[stage_in]], constant Uniforms& U [[buffer(1)]],
+            depth2d<float> depth [[texture(0)]]) {
+            uint2 pixel = uint2(in.position.xy);
+            float d = depth.read(pixel);
+            float3 P = screenPosition(in.uv,d,U);
+            return float4(gtaoGeometricNormal(pixel,d,P,float3(0,0,-1),U,depth),1);
+        }
+        """, options:nil)
+        func pipeline(_ name:String, depth:Bool) throws -> MTLRenderPipelineState {
+            let d = MTLRenderPipelineDescriptor()
+            d.vertexFunction = library.makeFunction(name:"fs_vertex")
+            d.fragmentFunction = library.makeFunction(name:name)
+            if depth { d.depthAttachmentPixelFormat = .depth32Float }
+            else { d.colorAttachments[0].pixelFormat = .rgba32Float }
+            return try device.makeRenderPipelineState(descriptor:d)
+        }
+        let depthPipeline = try pipeline("normal_fixture_depth",depth:true)
+        let normalPipeline = try pipeline("normal_boundary_fixture",depth:false)
+        let td = MTLTextureDescriptor.texture2DDescriptor(pixelFormat:.depth32Float,width:9,height:9,mipmapped:false)
+        td.usage = [.renderTarget,.shaderRead]
+        let depth = try XCTUnwrap(device.makeTexture(descriptor:td))
+        td.pixelFormat = .rgba32Float; td.storageMode = .shared
+        let output = try XCTUnwrap(device.makeTexture(descriptor:td))
+        let ds = MTLDepthStencilDescriptor(); ds.depthCompareFunction = .always; ds.isDepthWriteEnabled = true
+        let depthState = try XCTUnwrap(device.makeDepthStencilState(descriptor:ds))
+        let queue = try XCTUnwrap(device.makeCommandQueue())
+        var u = Uniforms(viewProj:matrix_identity_float4x4,lightDir:.zero,eye:.zero,
+            screen:SIMD4(9,9,4.5,0),camRight:SIMD4(1,0,0,0),camUp:SIMD4(0,1,0,0),
+            prevViewProj:matrix_identity_float4x4,temporal:.zero,shadowViewProj:matrix_identity_float4x4,
+            shadowParams:.zero,invViewProj:matrix_identity_float4x4,prevInvViewProj:matrix_identity_float4x4,
+            aoProjection:SIMD4(1,-0.1,1,1))
+        for axis in 0...1 { for side in [-1,1] { for background in [false,true] {
+            var center = SIMD2<Int>(4,4)
+            center[axis] = background ? 4 : (side < 0 ? 1 : 7)
+            var values = [Float](repeating:0.6,count:81)
+            var near = center; near[axis] += side
+            var far = center; far[axis] += side*2
+            var other = center; other[axis] -= side
+            var other2 = center; other2[axis] -= side*2
+            values[near.y*9+near.x] = 0.59
+            if background { values[far.y*9+far.x] = 1 }
+            values[other.y*9+other.x] = 0.64
+            values[other2.y*9+other2.x] = 0.68
+            let buffer = try XCTUnwrap(values.withUnsafeBytes { device.makeBuffer(bytes:$0.baseAddress!,length:$0.count,options:.storageModeShared) })
+            let command = try XCTUnwrap(queue.makeCommandBuffer())
+            let pass = MTLRenderPassDescriptor(); pass.depthAttachment.texture = depth
+            pass.depthAttachment.loadAction = .clear; pass.depthAttachment.storeAction = .store
+            let e = try XCTUnwrap(command.makeRenderCommandEncoder(descriptor:pass))
+            e.setRenderPipelineState(depthPipeline); e.setDepthStencilState(depthState)
+            e.setFragmentBuffer(buffer,offset:0,index:0)
+            e.drawPrimitives(type:.triangle,vertexStart:0,vertexCount:3); e.endEncoding()
+            let result = MTLRenderPassDescriptor(); result.colorAttachments[0].texture = output
+            result.colorAttachments[0].storeAction = .store
+            let f = try XCTUnwrap(command.makeRenderCommandEncoder(descriptor:result))
+            f.setRenderPipelineState(normalPipeline); f.setFragmentTexture(depth,index:0)
+            f.setFragmentBytes(&u,length:MemoryLayout<Uniforms>.stride,index:1)
+            f.drawPrimitives(type:.triangle,vertexStart:0,vertexCount:3); f.endEncoding()
+            command.commit(); command.waitUntilCompleted()
+            XCTAssertEqual(command.status,.completed,"\(String(describing:command.error))")
+            func position(_ p:SIMD2<Int>, _ d:Float) -> SIMD3<Float> {
+                let z = -0.1/(d-1)
+                return SIMD3((Float(p.x)+0.5)/9*2-1,(Float(p.y)+0.5)/9*2-1,1)*z
+            }
+            let P = position(center,0.6)
+            let tangent = (position(near,0.59)-P)*Float(side)
+            let perpendicular = axis == 0 ? SIMD3<Float>(0,1,0) : SIMD3<Float>(1,0,0)
+            var expected = normalize(cross(tangent,perpendicular))
+            if dot(expected,-P) < 0 { expected = -expected }
+            var pixel = SIMD4<Float>.zero
+            output.getBytes(&pixel,bytesPerRow:16,from:MTLRegionMake2D(center.x,center.y,1,1),mipmapLevel:0)
+            XCTAssertGreaterThan(dot(SIMD3(pixel.x,pixel.y,pixel.z),expected),0.9999,
+                "Missing second neighbor: axis \(axis), side \(side), background \(background)")
+        } } }
+    }
+}

--- a/Tests/GPUSimRendererTests/WallCornerTests.swift
+++ b/Tests/GPUSimRendererTests/WallCornerTests.swift
@@ -1,0 +1,98 @@
+import MetalKit
+import CoreGraphics
+import ImageIO
+import XCTest
+@testable import GPUSimRenderer
+
+@MainActor
+final class WallCornerTests: XCTestCase {
+    private final class Scene: GPUSimRenderableScene {
+        let renderDevice: MTLDevice
+        var renderBodyCount: Int { 0 }
+        var renderRigidInstanceCount: Int { 0 }
+        var rendererStateIsValid: Bool { true }
+        var renderCameraHint: GPUSimRenderCameraHint { .init() }
+        var rigidMeshRenderSurface: GPUSimRigidMeshRenderSurface? { nil }
+        var softRenderSurface: GPUSimSoftRenderSurface? { nil }
+        var skinnedRenderSurface: GPUSimSkinnedRenderSurface? { nil }
+        var convexDebugRenderSurface: GPUSimConvexDebugRenderSurface? { nil }
+        init(_ device: MTLDevice) { renderDevice = device }
+        func encodeRenderInstances(_ commandBuffer: MTLCommandBuffer, instances: MTLBuffer,
+            colorMode: GPUSimRenderColorMode, appearanceOverrides: MTLBuffer?) throws {}
+    }
+
+    func testSlantedWallJointKeepsOcclusionThroughPixelGridCrossings() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { throw XCTSkip("Metal unavailable") }
+        let scene = Scene(device)
+        let renderer = try GPUSimRenderer(device: device)
+        try renderer.setScene(scene)
+        renderer.auxiliaryInstances = [
+            .init(primitive: .box(size: SIMD3(0.1,3.2,2.6)), position: SIMD3(1.27,0,1.3), color: SIMD3(repeating: 0.75)),
+            .init(primitive: .box(size: SIMD3(3.6,0.09,2.6)), position: SIMD3(-0.48,-1.645,1.3), color: SIMD3(repeating: 0.75))
+        ]
+        let w = 1120, h = 760
+        let view = MTKView(frame: CGRect(x:0,y:0,width:w,height:h), device:device)
+        renderer.configure(view); view.isPaused = true
+        view.autoResizeDrawable = false; view.drawableSize = CGSize(width:w,height:h)
+        renderer.automaticallyFramesScene = false
+        renderer.options = .init(contactShadows:false, showsGroundPlane:false)
+        renderer.options.sunDirection = normalize(SIMD3(-1,0.18,-0.75))
+        var pixels: [UInt8] = []
+        renderer.frameCompletionHandler = { texture, _ in
+            pixels = [UInt8](repeating:0,count:w*h*4)
+            pixels.withUnsafeMutableBytes { texture.getBytes($0.baseAddress!, bytesPerRow:w*4,
+                from:MTLRegionMake2D(0,0,w,h), mipmapLevel:0) }
+        }
+        for targetX: Float in [1.10, 1.11, 1.34] {
+            renderer.setCamera(position: SIMD3(-0.15,-0.15,1.65),
+                target: SIMD3(targetX,-1.6,1.35), up: SIMD3(0,0,1))
+            renderer.options.ambientOcclusion = true
+            view.draw()
+            XCTAssertNil(renderer.runtimeFailure)
+            XCTAssertEqual(pixels.count, w*h*4)
+            guard pixels.count == w*h*4 else { return }
+            let shaded = pixels
+            try save(shaded, width:w, height:h, name:"joint-\(targetX)")
+            renderer.options.ambientOcclusion = false
+            view.draw()
+            XCTAssertNil(renderer.runtimeFailure)
+
+            // Project the known joint, independently of its AO. Testing an
+            // off-center vertical line crosses every subpixel edge alignment.
+            let vp = renderer.projectionMatrix(aspect:Float(w)/Float(h)) * renderer.viewMatrix
+            func project(_ z: Float) -> SIMD2<Float> {
+                let clip = vp * SIMD4<Float>(1.22,-1.6,z,1)
+                return SIMD2((clip.x/clip.w*0.5+0.5)*Float(w), (0.5-clip.y/clip.w*0.5)*Float(h))
+            }
+            let bottom = project(0), top = project(2.6)
+            var peak: Float = 0
+            for y in 80..<(h-80) {
+                let t = (Float(y)+0.5-bottom.y)/(top.y-bottom.y)
+                let x = Int(bottom.x + t*(top.x-bottom.x))
+                for q in (x-2)...(x+2) {
+                    let index = (y*w+q)*4
+                    peak = max(peak, Float(shaded[index])/Float(max(pixels[index],1)))
+                }
+            }
+            print("Wall joint maximum AO-on / AO-off brightness at \(targetX): \(peak)")
+            // A perpendicular wall blocks substantial ambient light at the
+            // crease. The old nearest-depth normal invented bright cracks
+            // above 0.9; allow a generous margin for quantization and MSAA.
+            XCTAssertLessThan(peak, 0.85, "The joint must remain occluded across pixel-grid crossings")
+        }
+    }
+
+    private func save(_ pixels:[UInt8],width:Int,height:Int,name:String) throws {
+        guard let path = ProcessInfo.processInfo.environment["GTAO_TEST_OUTPUT"] else { return }
+        try FileManager.default.createDirectory(atPath:path,withIntermediateDirectories:true)
+        let gray = stride(from:0,to:pixels.count,by:4).map { pixels[$0] }
+        let provider = try XCTUnwrap(CGDataProvider(data:Data(gray) as CFData))
+        let image = try XCTUnwrap(CGImage(width:width,height:height,bitsPerComponent:8,bitsPerPixel:8,
+            bytesPerRow:width,space:CGColorSpaceCreateDeviceGray(),bitmapInfo:[],provider:provider,
+            decode:nil,shouldInterpolate:false,intent:.defaultIntent))
+        let url = URL(fileURLWithPath:path).appendingPathComponent(name+".png")
+        let target = try XCTUnwrap(CGImageDestinationCreateWithURL(url as CFURL,"public.png" as CFString,1,nil))
+        CGImageDestinationAddImage(target,image,nil)
+        XCTAssertTrue(CGImageDestinationFinalize(target))
+    }
+}


### PR DESCRIPTION
Fast AO produced broken bright cracks along the new kitchen's concave wall joint when the camera put the crease slightly off-center. This reproduces with two plain boxes and contact shadows disabled, and disappears with AO disabled.

Geometric-normal reconstruction chose neighbors by depth distance. At a concave crease, the nearer sample can belong to the other wall, creating an incorrect receiver plane and rejecting real occlusion. Select each derivative side by how its two hardware-depth samples extrapolate to the receiver instead: hardware depth is affine on projected planes. Apply this to AO evaluation and both spatial filters. If either second neighbor on an axis is unavailable, compare adjacent-depth differences on both sides; never compare an extrapolation residual against a first-order difference. AO sample count, radius, contrast, and HQ behavior are unchanged.

Eight GPU boundary cases cover both axes and directions, with second neighbors missing at the viewport edge or in background. All eight fail before the symmetric fallback fix and pass afterward.

The full-renderer regression covers three off-center camera positions with native MSAA. Bright seam pixels previously reached 0.916 of unoccluded brightness; the corrected fixture remains below 0.611. The full kitchen capture is smooth at the same failing camera.

Validation: 84 renderer tests passed, one optional benchmark skipped; main AVBD app Release build passed. The initial wall fix’s optional AO benchmark was run separately on Apple M5 at 1440×858 AO resolution: three-trial median 6.84 ms before, 6.52 ms after. Ranges overlap (6.37–6.91 and 6.50–6.97 ms), so this is not a claimed speedup. Four additional depth reads per geometric-normal reconstruction; no new passes, allocations, or temporal history. Captures and benchmark instrumentation remain local and are not committed.

Stacked on #30, the configurable-sunlight revision used by the new kitchen.
