### PR TITLE
Fix Swift type-check timeouts in cable demos and validation

### DIFF
--- a/Examples/Cables/CableCollisionValidation.swift
+++ b/Examples/Cables/CableCollisionValidation.swift
@@ -60,9 +60,17 @@ func validateTwistingContact() throws {
     }
     var s = Demos.cableTwisting(segments: value("--segments", default: 40))
     if args.contains("--mixed") {
-        let vertices = [-1,1].flatMap { x in [-1,1].flatMap { y in [-1,1].map { z in
-            F3(Float(x),Float(y),Float(z)) * 0.1
-        } } }
+        let signs = [-1, 1]
+        var vertices: [F3] = []
+        vertices.reserveCapacity(8)
+        for x in signs {
+            for y in signs {
+                for z in signs {
+                    let point = F3(Float(x), Float(y), Float(z))
+                    vertices.append(point * 0.1)
+                }
+            }
+        }
         let hull = s.addBody(size: F3(repeating: 0.2), density: 0, friction: 0.5,
                              position: F3(10,10,0), collisionEnabled: false)
         _ = s.addCollider(body: hull, size: F3(repeating: 0.2), convexHullVertices: vertices)

--- a/Sources/GPUSimDemos/CableEthernet.swift
+++ b/Sources/GPUSimDemos/CableEthernet.swift
@@ -515,7 +515,10 @@ private func ethernetServiceLoop(_ points: [F3], segments: Int) -> [F3] {
             let b: F3 = p2 - p0
             let c: F3 = p0 * 2 - p1 * 5 + p2 * 4 - p3
             let d: F3 = -p0 + p1 * 3 - p2 * 3 + p3
-            var p = (a + b * t + c * (t*t) + d * (t*t*t)) * 0.5
+            let t2 = t * t
+            let t3 = t2 * t
+            let curve = a + b * t + c * t2 + d * t3
+            var p = curve * 0.5
             p.z = max(0.003, p.z)
             dense.append(p)
         }

--- a/Sources/GPUSimDemos/CablePlaygrounds.swift
+++ b/Sources/GPUSimDemos/CablePlaygrounds.swift
@@ -197,8 +197,9 @@ private func addCableClip(_ s: inout PhysicsScene, center: F3, axis: F3,
             for a in 0..<angular {
                 let angle = Float.pi / 4 + Float(a) * (1.5 * .pi) / Float(angular - 1)
                 let radius: Float = 0.04 + 0.0175 * Float(r)
-                let position = center + axis * (Float(u) - 1) * 0.06
-                    + radius * (front * cos(angle) + across * sin(angle))
+                let axialOffset = axis * (Float(u) - 1) * 0.06
+                let ringOffset = radius * (front * cos(angle) + across * sin(angle))
+                let position = center + axialOffset + ringOffset
                 let node = s.addParticle(radius: 0.005, mass: 0.0008,
                                         friction: friction, position: position)
                 if r == radial - 1 && cos(angle) < -0.45 { s.bodies[node].density = 0 }


### PR DESCRIPTION
Building `cable-validation` with the local Swift toolchain failed with “unable to type-check this expression in reasonable time” in three cable demo/validation expressions. Split the vector arithmetic into intermediate values and replace a nested `flatMap` with equivalent ordered loops so the target builds.

This is a small follow-up to #35, targeting `feat/native-cables` because the cable implementation is still on that branch. No solver, material, contact or geometry formulas change.

Validation on Apple M5:
- Release `cable-validation` build passes.
- `cable-validation --cpu-only`: all checks pass.
- `cable-validation --benchmark`: CPU/Metal checks and benchmark pass; 1,024 segments measured 0.318 ms/step without contact and 0.677 ms/step with floor contact at 240 Hz / 12 iterations. These are current timings, not a claimed speedup.
