### PR TITLE
Fix Swift type-check timeout in cable volume test

### DIFF
--- a/Tests/PhysicsAVBDTests/CableDemoTests.swift
+++ b/Tests/PhysicsAVBDTests/CableDemoTests.swift
@@ -37,7 +37,10 @@ final class CableDemoTests: XCTestCase {
         XCTAssertTrue(boundaryEdges.values.allSatisfy { $0 == 2 }, "clip skins must be watertight")
         // Four 270-degree annular clips, 120 mm long. Linear surface facets
         // approximate the analytic annulus within two percent.
-        let expected: Float = 4 * 0.12 * 0.75 * .pi * (0.075 * 0.075 - 0.04 * 0.04)
+        let outerRadius: Float = 0.075
+        let innerRadius: Float = 0.04
+        let annularArea = Float.pi * (outerRadius * outerRadius - innerRadius * innerRadius)
+        let expected: Float = 4 * 0.12 * 0.75 * annularArea
         XCTAssertEqual(volume, expected, accuracy: expected * 0.02)
     }
 


### PR DESCRIPTION
The release test target fails to compile on the current Swift toolchain because the annular-volume expression in `CableDemoTests` exceeds the type-checking time limit. Split the same calculation into explicitly typed radii and area, preserving the expected volume and existing tolerance.

Validation: the complete test target compiled in the merged integration checkout, and 12 selected cable authoring, mechanics, and contact tests passed. The original compiler failure and successful rerun are retained locally. No simulator behavior changes.
